### PR TITLE
Fix image tag for PR build

### DIFF
--- a/.github/workflows/docker-publish-api.yml
+++ b/.github/workflows/docker-publish-api.yml
@@ -20,6 +20,8 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: icr.io
+  # Use ICR_NAMESPACE for main branches else use github repo name for PRs
+  IMAGE_NAME: ${{ secrets.ICR_NAMESPACE || github.repository }}
 
 
 jobs:
@@ -61,7 +63,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ secrets.ICR_NAMESPACE }}/api
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/api
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish-keycloak.yml
+++ b/.github/workflows/docker-publish-keycloak.yml
@@ -18,6 +18,8 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: icr.io
+  # Use ICR_NAMESPACE for main branches else use github repo name for PRs
+  IMAGE_NAME: ${{ secrets.ICR_NAMESPACE || github.repository }}
 
 
 jobs:
@@ -61,7 +63,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ secrets.ICR_NAMESPACE }}/keycloak
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/keycloak
           tags: |
             type=schedule
             type=ref,event=branch

--- a/.github/workflows/docker-publish-web.yml
+++ b/.github/workflows/docker-publish-web.yml
@@ -20,6 +20,8 @@ on:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: icr.io
+  # Use ICR_NAMESPACE for main branches else use github repo name for PRs
+  IMAGE_NAME: ${{ secrets.ICR_NAMESPACE || github.repository }}
 
 
 jobs:
@@ -57,7 +59,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ secrets.ICR_NAMESPACE }}/web
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
- Use default repository name as part of name in image tag on PR builds 