### PR TITLE
Add support for power10 machine type

### DIFF
--- a/api/controllers/util/util.go
+++ b/api/controllers/util/util.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	IBMResourceCRNRegexp = regexp.MustCompile(`^crn:v[0-9]:(?P<cloudName>[^:]*):(?P<cloudType>[^:]*):(?P<serviceName>[^:]*):(?P<location>[^:]*):a/(?P<account>[^:]*):(?P<guid>[^:]*)::$`)
-	availableSysType     = []string{"s922", "e980"}
+	availableSysType     = []string{"s922", "e980", "s1022"}
 	availableProcType    = []string{"dedicated", "shared", "capped"}
 )
 


### PR DESCRIPTION
```
vm:
    capacity:
      cpu: '0.25'
      memory: 4
    crn: 'crn:v1:bluemix:public:power-iaas:lon06:a/108655d3ff9e4489b1c29e83df48623d:f652853b-c022-405e-9f11-e30259f930e7::'
    image: centos-9-stream-pac-20251201
    network: ''
    processor_type: shared
    system_type: s1022
status:
  message: sys type s1022 is not supported
```
  Allow s1022 to be validated as a valid machine type 
  