### PR TITLE
Fix Catalog name information while deploying from admin portal

### DIFF
--- a/web/src/components/Catalogs-admin.jsx
+++ b/web/src/components/Catalogs-admin.jsx
@@ -156,7 +156,7 @@ const CatalogsAdmin = () => {
         )}
         {actionProps?.key === BUTTON_REQUEST && (
           <DeployCatalog
-            selectRows={selectRows}
+            selectRows={selectRows[0]}
             setActionProps={setActionProps}
             response={handleResponse}
           />

--- a/web/src/components/PopUp/DeployCatalog.jsx
+++ b/web/src/components/PopUp/DeployCatalog.jsx
@@ -10,7 +10,19 @@ const DeployCatalog = ({ selectRows, setActionProps, response }) => {
   const [primaryButtonDisabled, setPrimaryButtonDisabled] = useState(false);
   const [primaryButtonText, setPrimaryButtonText] = useState("Submit");
   const [emptyServiceName, setEmptyServiceName] = useState(true)
-  let name = selectRows.name;
+  const getCellValue = (data, key) => {
+    if (!data) return '';
+    
+    // Admin Persona (Carbon Table format)
+    if (data.cells) {
+      const cell = data.cells.find(c => c.id.endsWith(`:${key}`));
+      return cell ? cell.value : '';
+    }
+
+    // User Persona (Standard Object format)
+    return data[key] || '';
+  };
+  const name = getCellValue(selectRows, 'name');
   let navigate = useNavigate();
   const onSubmit = async () => {
     let title = "";


### PR DESCRIPTION
Fixes - [Catalog name not appearing while deploying from admin portal](https://github.com/IBM/power-access-cloud/issues/16)

**Admin Persona:** Uses a Carbon DataTable which transforms data into a nested "Table Model" where values are stored within a cells
**User Persona:** Uses a standard Tile layout that passes a raw API object where values are properties (e.g., row.name).
To fix it, implemented a helper function to handle both the cases in DeployCatalog.
With this changes we can see that catalog name is displayed when trying to deploy from admin portal.
<img width="1700" height="837" alt="Screenshot 2026-01-05 at 09 58 30" src="https://github.com/user-attachments/assets/1466fbf6-839d-49fe-85ab-273641b83afe" />
