### PR TITLE
Read current service expiry from service object for service extension…

### DIFF
--- a/api/internal/pkg/pac-go-server/services/backend_test.go
+++ b/api/internal/pkg/pac-go-server/services/backend_test.go
@@ -415,6 +415,33 @@ func getResource(apiType string, customValues map[string]interface{}) interface{
 			}
 		}
 		return &request
+	case "get-request-more-than-5days":
+		request := models.Request{
+			ID:            [12]byte{1},
+			UserID:        "12345",
+			Justification: "justification",
+			Comment:       "comment",
+			CreatedAt:     time.Time{},
+			RequestType:   "SERVICE_EXPIRY",
+			GroupAdmission: &models.GroupAdmission{
+				GroupID:   "test-group",
+				Group:     "manager",
+				Requester: "test-user",
+			},
+			ServiceExpiry: &models.ServiceExpiry{
+				Name:   "test-service",
+				Expiry: time.Now().AddDate(0, 0, 6),
+			},
+		}
+		// Update request with custom values if provided
+		for key, value := range customValues {
+			if fieldValue := reflect.ValueOf(&request).Elem().FieldByName(key); fieldValue.IsValid() {
+				if value != nil {
+					fieldValue.Set(reflect.ValueOf(value))
+				}
+			}
+		}
+		return &request
 	case "get-key-by-id":
 		key := models.Key{
 			ID:      [12]byte{1},

--- a/api/internal/pkg/pac-go-server/services/request_test.go
+++ b/api/internal/pkg/pac-go-server/services/request_test.go
@@ -148,6 +148,17 @@ func TestUpdateServiceExpiryRequest(t *testing.T) {
 			httpStatus: http.StatusBadRequest,
 			request:    getResource("get-request-by-id-before-expiry", nil).(*models.Request),
 		},
+		{
+			name: "service expiry extension beyond maximum allowed",
+			mockFunc: func() {
+				mockClient.EXPECT().GetService(gomock.Any()).Return(getResource("get-service", nil).(pac.Service), nil).Times(1)
+			},
+			requestContext: formContext(customValues{
+				"userid": "12345",
+			}),
+			httpStatus: http.StatusBadRequest,
+			request:    getResource("get-request-more-than-5days", nil).(*models.Request),
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
- Recently we have added the service limit extension check as part of this PR- https://github.com/IBM/power-access-cloud/pull/27. Since the current expiry date and time was read from db and for the new service the db entry does not exist, this check is currently getting by passed. So instead of reading from DB, it should be read from service object.