### PR TITLE
Fix Delete service from admin portal

### DIFF
--- a/web/src/components/PopUp/DeleteService.jsx
+++ b/web/src/components/PopUp/DeleteService.jsx
@@ -7,8 +7,19 @@ import { Modal } from "@carbon/react";
 const DeleteService = ({pagename, selectRows, setActionProps, response }) => {
   const [primaryButtonDisabled, setPrimaryButtonDisabled] = useState(false);
   const [primaryButtonText, setPrimaryButtonText] = useState("Delete");
-  // const name = selectRows[0]?.id;
-  const name = selectRows[0]?.name;
+  const getCellValue = (data, key) => {
+    if (!data) return '';
+    
+    // Admin Persona (Carbon Table format)
+    if (data.cells) {
+      const cell = data.cells.find(c => c.id.endsWith(`:${key}`));
+      return cell ? cell.value : '';
+    }
+
+    // User Persona (Standard Object format)
+    return data[key] || '';
+  };
+  const name = getCellValue(selectRows[0], 'name');
   let navigate = useNavigate();
 
   const onSubmit = async () => {


### PR DESCRIPTION
Admin Persona: Uses a Carbon DataTable which transforms data into a nested "Table Model" where values are stored within a cells
User Persona: Uses a standard Tile layout that passes a raw API object where values are properties (e.g., row.name).
To fix it, implemented a helper function to handle both the cases in DeleteService.

Admin Persona.

<img width="1100" height="302" alt="Screenshot 2026-02-16 at 17 52 54" src="https://github.com/user-attachments/assets/6e500b44-1439-49f9-a650-2df8341f6774" />

User persona

<img width="1087" height="459" alt="Screenshot 2026-02-16 at 17 53 49" src="https://github.com/user-attachments/assets/7bfe006d-8c48-4304-b24e-32388aa99391" />
