### PR TITLE
Configurable log level

### DIFF
--- a/api/config/manager/manager.yaml
+++ b/api/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager-config
-#        env:
+#       env:
 #        - name: IBMCLOUD_APIKEY
 #          valueFrom:
 #            secretKeyRef:

--- a/api/internal/pkg/pac-go-server/logger/logger.go
+++ b/api/internal/pkg/pac-go-server/logger/logger.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -11,13 +13,49 @@ import (
 var Logger *zap.Logger
 
 func init() {
+	Logger = InitLogger()
+}
+
+// InitLogger initializes the logger with configurable log level from environment
+func InitLogger() *zap.Logger {
+	// Get log level from environment variable, default to "info"
+	logLevel := strings.ToLower(os.Getenv("LOG_LEVEL"))
+	if logLevel == "" {
+		logLevel = "info"
+	}
+
+	// Parse log level
+	var level zapcore.Level
+	switch logLevel {
+	case "debug":
+		level = zapcore.DebugLevel
+	case "info":
+		level = zapcore.InfoLevel
+	case "warn", "warning":
+		level = zapcore.WarnLevel
+	case "error":
+		level = zapcore.ErrorLevel
+	case "fatal":
+		level = zapcore.FatalLevel
+	default:
+		level = zapcore.InfoLevel
+		log.Printf("Invalid LOG_LEVEL '%s', defaulting to 'info'\n", logLevel)
+	}
+
+	// Create logger configuration
 	cfg := zap.NewProductionConfig()
+	cfg.Level = zap.NewAtomicLevelAt(level)
 	cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339)
+
 	logger, err := cfg.Build()
 	if err != nil {
 		log.Println("Error while initializing logger.", err)
+		// Return a no-op logger as fallback
+		return zap.NewNop()
 	}
-	Logger = logger
+
+	logger.Info("Logger initialized", zap.String("level", logLevel))
+	return logger
 }
 
 func GetLogger() *zap.Logger {

--- a/api/internal/pkg/pac-go-server/router/router.go
+++ b/api/internal/pkg/pac-go-server/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/gin-gonic/gin"
@@ -29,6 +30,24 @@ var (
 func init() {
 	client = gocloak.NewClient(hostname)
 	internalClient = keycloak.NewGoCloakClient(hostname)
+	
+	// Set GIN mode based on LOG_LEVEL or GIN_MODE environment variable
+	setGinMode()
+}
+
+// setGinMode configures GIN's logging mode based on environment variables
+func setGinMode() {
+	ginMode := os.Getenv("GIN_MODE")
+	if ginMode == "" {
+		// If GIN_MODE not set, derive from LOG_LEVEL
+		logLevel := strings.ToLower(os.Getenv("LOG_LEVEL"))
+		if logLevel == "debug" {
+			ginMode = gin.DebugMode
+		} else {
+			ginMode = gin.ReleaseMode
+		}
+	}
+	gin.SetMode(ginMode)
 }
 
 func CreateRouter() *gin.Engine {


### PR DESCRIPTION
Making log level configurable to enable debugging for pac go server and event notifier. The controller-manager defaults to Debug (keeping it the same as of now)