### PR TITLE
feat(notifier): render portal URL as clickable hyperlink in email body

### DIFF
--- a/api/cmd/event-notifier/main.go
+++ b/api/cmd/event-notifier/main.go
@@ -18,6 +18,7 @@ var (
 	serviceAccount         = os.Getenv("KEYCLOAK_SERVICE_ACCOUNT")
 	serviceAccountPassword = os.Getenv("KEYCLOAK_SERVICE_ACCOUNT_PASSWORD")
 	envPrefixForEmail      = os.Getenv("EMAIL_SUBJECT_PREFIX")
+	portalURL              = os.Getenv("PORTAL_URL")
 )
 
 const cappedEvents = 30000
@@ -28,6 +29,7 @@ func validateEnvVars() error {
 		"KEYCLOAK_HOSTNAME":                 hostname,
 		"KEYCLOAK_SERVICE_ACCOUNT":          serviceAccount,
 		"KEYCLOAK_SERVICE_ACCOUNT_PASSWORD": serviceAccountPassword,
+		"PORTAL_URL":                        portalURL,
 	}
 	for k, v := range globalVars {
 		if v == "" {

--- a/api/internal/pkg/notifier/client/mail/mail.go
+++ b/api/internal/pkg/notifier/client/mail/mail.go
@@ -32,7 +32,7 @@ func (m *Mail) Notify(event models.Event) error {
 	if err != nil {
 		return err
 	}
-	content := mail.NewContent("text", plainTextContent)
+	content := mail.NewContent("text/html", plainTextContent)
 	m1.AddContent(content)
 
 	personalization := mail.NewPersonalization()

--- a/api/internal/pkg/pac-go-server/models/events.go
+++ b/api/internal/pkg/pac-go-server/models/events.go
@@ -2,7 +2,8 @@ package models
 
 import (
 	"bytes"
-	"text/template"
+	"html/template"
+	"os"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -130,28 +131,37 @@ func (e *Event) SetLog(level EventLogLevel, message string) {
 }
 
 var bodyTemplate = `
-{{- if .Log.Message -}}
+{{- if .Event.Log.Message -}}
 Hi,
-
-{{ .Log.Message }}
-
-Please visit the IBM® Power® Access Cloud portal for more details.
-
-Note: This is an auto-generated email. Please do not reply to this email.
-Generated at: {{ .CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}
-
-Thanks,
-IBM® Power® Access Cloud Team.
+<br><br>
+{{ .Event.Log.Message }}
+<br><br>
+Please visit the <a href="{{ .PortalURL }}">IBM® Power® Access Cloud</a> portal for more details.
+<br><br>
+Note: This is an auto-generated email. Please do not reply to this email.<br>
+Generated at: {{ .Event.CreatedAt.Format "Jan 02, 2006 15:04:05 UTC" }}
+<br><br>
+Thanks,<br>
+IBM® Power®; Access Cloud Team.
 {{- end -}}
 `
+
+type mailTemplateData struct {
+	Event     *Event
+	PortalURL string
+}
 
 func (e *Event) ComposeMailBody() (string, error) {
 	tmpl, err := template.New("pac").Parse(bodyTemplate)
 	if err != nil {
 		return "", err
 	}
+	data := mailTemplateData{
+		Event:     e,
+		PortalURL: os.Getenv("PORTAL_URL"),
+	}
 	var tpl bytes.Buffer
-	if err := tmpl.Execute(&tpl, e); err != nil {
+	if err := tmpl.Execute(&tpl, data); err != nil {
 		return "", err
 	}
 	return tpl.String(), nil


### PR DESCRIPTION
This PR introduces a `PORTAL_URL` environment variable to embed a clickable hyperlink to the IBM® Power® Access Cloud portal within the email body. The email template has been migrated from plain text to HTML, and the mail content type has been updated accordingly.

With this update, the event-notifier also checks for `PORTAL_URL` env var to be available at event-notifier startup.

Closes #84 