### PR TITLE
Migrate go mongo driver to v2

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
 	github.com/tbaehler/gin-keycloak v1.7.0
-	go.mongodb.org/mongo-driver v1.17.7
+	go.mongodb.org/mongo-driver/v2 v2.6.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.52.0
 	golang.org/x/text v0.37.0
@@ -82,7 +82,6 @@ require (
 	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -93,7 +92,7 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.16.7 // indirect
+	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
@@ -101,7 +100,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
@@ -118,9 +116,10 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/scram v1.2.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -175,8 +175,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
-github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/cel-go v0.12.6 h1:kjeKudqV0OygrAqA9fX6J55S8gj+Jre2tckIm5RoG4M=
 github.com/google/cel-go v0.12.6/go.mod h1:Jk7ljRzLBhkmiAwBoUxB1sZSCVBAzkqPF25olK/iRDw=
 github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
@@ -219,8 +217,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
-github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.17.6 h1:60eq2E/jlfwQXtvZEeBUYADs+BwKBWURIY+Gj2eRGjI=
+github.com/klauspost/compress v1.17.6/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -254,8 +252,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
-github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -349,8 +345,8 @@ github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
-github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
-github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
+github.com/xdg-go/scram v1.2.0 h1:bYKF2AEwG5rqd1BumT4gAnvwU/M9nBp2pTSxeZw7Wvs=
+github.com/xdg-go/scram v1.2.0/go.mod h1:3dlrS0iBaWKYVt2ZfA4cj48umJZ+cAEbR6/SjLA88I8=
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -362,8 +358,10 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
-go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
+go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver/v2 v2.6.2 h1:wpq35pIbOVHGW5NfWhOMACfr5+ceptFgBpkZC4THe2E=
+go.mongodb.org/mongo-driver/v2 v2.6.2/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=

--- a/api/internal/pkg/pac-go-server/db/mongodb/db.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/db.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/db"
 )
@@ -41,7 +41,7 @@ func New() db.DB {
 func (db *MongoDB) Connect() error {
 	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
 	opts := options.Client().ApplyURI(db.URI).SetServerAPIOptions(serverAPI)
-	client, err := mongo.Connect(context.TODO(), opts)
+	client, err := mongo.Connect(opts)
 	if err != nil {
 		return fmt.Errorf("error connecting to MongoDB: %w", err)
 	}

--- a/api/internal/pkg/pac-go-server/db/mongodb/event.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/event.go
@@ -6,10 +6,9 @@ import (
 	"log"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 )
@@ -134,7 +133,7 @@ func (db *MongoDB) MarkEventAsNotified(id string) error {
 	if id == "" {
 		return fmt.Errorf("id cannot be empty")
 	}
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid id: %w", err)
 	}

--- a/api/internal/pkg/pac-go-server/db/mongodb/feedback.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/feedback.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/services"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // InsertFeedback - insert feedback record into the DB

--- a/api/internal/pkg/pac-go-server/db/mongodb/key.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/key.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/utils"
@@ -53,7 +52,7 @@ func (db *MongoDB) CreateKey(keys *models.Key) error {
 func (db *MongoDB) GetKeyByID(id string) (*models.Key, error) {
 	var key models.Key
 
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid id: %w", err)
 	}
@@ -74,7 +73,7 @@ func (db *MongoDB) GetKeyByID(id string) (*models.Key, error) {
 }
 
 func (db *MongoDB) DeleteKey(id string) error {
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid id: %w", err)
 	}

--- a/api/internal/pkg/pac-go-server/db/mongodb/maintenance.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/maintenance.go
@@ -6,9 +6,8 @@ import (
 	"time"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // GetAllMaintenanceWindows retrieves all non-deleted maintenance windows from the database
@@ -39,7 +38,7 @@ func (db *MongoDB) GetMaintenanceWindowByID(id string) (*models.MaintenanceWindo
 	ctx, cancel := context.WithTimeout(context.Background(), dbContextTimeout)
 	defer cancel()
 
-	objectID, err := primitive.ObjectIDFromHex(id)
+	objectID, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid maintenance window ID: %w", err)
 	}
@@ -112,7 +111,7 @@ func (db *MongoDB) DeleteMaintenanceWindow(id string, deletedBy string, deletedA
 	ctx, cancel := context.WithTimeout(context.Background(), dbContextTimeout)
 	defer cancel()
 
-	objectID, err := primitive.ObjectIDFromHex(id)
+	objectID, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid maintenance window ID: %w", err)
 	}

--- a/api/internal/pkg/pac-go-server/db/mongodb/quota.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/quota.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/zap"
 
 	log "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/logger"

--- a/api/internal/pkg/pac-go-server/db/mongodb/request.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/request.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 )
@@ -48,7 +47,7 @@ func (db *MongoDB) NewRequest(request *models.Request) (string, error) {
 		return "", fmt.Errorf("error inserting request: %w", err)
 	}
 
-	oid, ok := res.InsertedID.(primitive.ObjectID)
+	oid, ok := res.InsertedID.(bson.ObjectID)
 	if !ok {
 		return "", errors.New("unable to get inserted id for request")
 	}
@@ -85,7 +84,7 @@ func (db *MongoDB) GetRequestByGroupIDAndUserID(groupID string, userID string) (
 func (db *MongoDB) GetRequestByID(id string) (*models.Request, error) {
 	var request models.Request
 
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid id: %w", err)
 	}
@@ -107,7 +106,7 @@ func (db *MongoDB) GetRequestByID(id string) (*models.Request, error) {
 }
 
 func (db *MongoDB) DeleteRequest(id string) error {
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid id: %w", err)
 	}
@@ -123,7 +122,7 @@ func (db *MongoDB) DeleteRequest(id string) error {
 }
 
 func (db *MongoDB) UpdateRequestState(id string, state models.RequestStateType) error {
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid id: %w", err)
 	}
@@ -139,7 +138,7 @@ func (db *MongoDB) UpdateRequestState(id string, state models.RequestStateType) 
 }
 
 func (db *MongoDB) UpdateRequestStateWithComment(id string, state models.RequestStateType, comment string) error {
-	objectId, err := primitive.ObjectIDFromHex(id)
+	objectId, err := bson.ObjectIDFromHex(id)
 	if err != nil {
 		return fmt.Errorf("invalid id: %w", err)
 	}

--- a/api/internal/pkg/pac-go-server/db/mongodb/tnc.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/tnc.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 	"go.uber.org/zap"
 
 	log "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/logger"
@@ -42,7 +42,7 @@ func (db *MongoDB) AcceptTermsAndConditions(terms *models.TermsAndConditions) er
 	defer cancel()
 	filter := bson.D{{Key: "user_id", Value: terms.UserID}}
 	update := bson.D{{Key: "$set", Value: bson.D{{Key: "user_id", Value: terms.UserID}, {Key: "accepted", Value: terms.Accepted}, {Key: "accepted_at", Value: terms.AcceptedAt}}}}
-	opts := options.Update().SetUpsert(true)
+	opts := options.UpdateOne().SetUpsert(true)
 	_, err := collection.UpdateOne(ctx, filter, update, opts)
 	if err != nil {
 		return fmt.Errorf("error updating terms and coditions: %w", err)

--- a/api/internal/pkg/pac-go-server/models/events.go
+++ b/api/internal/pkg/pac-go-server/models/events.go
@@ -5,7 +5,7 @@ import (
 	"text/template"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type EventType string
@@ -44,7 +44,7 @@ const (
 
 type Event struct {
 	// ID is the event identifier
-	ID primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID bson.ObjectID `json:"id" bson:"_id,omitempty"`
 	// EventType is the event type
 	Type EventType `json:"type" bson:"type"`
 	// CreatedAt is the time the event was created

--- a/api/internal/pkg/pac-go-server/models/feedback.go
+++ b/api/internal/pkg/pac-go-server/models/feedback.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type Rating string
@@ -17,7 +17,7 @@ const (
 )
 
 type Feedback struct {
-	ID      primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID      bson.ObjectID `json:"id" bson:"_id,omitempty"`
 	UserID  string             `json:"user_id" bson:"user_id,omitempty"`
 	Rating  Rating             `json:"rating" bson:"rating,omitempty"`
 	Comment string             `json:"comment" bson:"comment,omitempty" binding:"max=250"`

--- a/api/internal/pkg/pac-go-server/models/key.go
+++ b/api/internal/pkg/pac-go-server/models/key.go
@@ -1,9 +1,9 @@
 package models
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import "go.mongodb.org/mongo-driver/v2/bson"
 
 type Key struct {
-	ID      primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID      bson.ObjectID `json:"id" bson:"_id,omitempty"`
 	UserID  string             `json:"user_id" bson:"user_id,omitempty"`
 	Name    string             `json:"name" bson:"name,omitempty"`
 	Content string             `json:"content" bson:"content,omitempty"`

--- a/api/internal/pkg/pac-go-server/models/maintenance.go
+++ b/api/internal/pkg/pac-go-server/models/maintenance.go
@@ -3,12 +3,12 @@ package models
 import (
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // MaintenanceWindow represents a single maintenance notification window
 type MaintenanceWindow struct {
-	ID        primitive.ObjectID `bson:"_id" json:"id"`
+	ID        bson.ObjectID `bson:"_id" json:"id"`
 	Enabled   bool               `bson:"enabled" json:"enabled"`
 	StartTime time.Time          `bson:"start_time" json:"start_time"`
 	EndTime   time.Time          `bson:"end_time" json:"end_time"`

--- a/api/internal/pkg/pac-go-server/models/quota.go
+++ b/api/internal/pkg/pac-go-server/models/quota.go
@@ -1,9 +1,9 @@
 package models
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import "go.mongodb.org/mongo-driver/v2/bson"
 
 type Quota struct {
-	ID       primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID       bson.ObjectID `json:"id" bson:"_id,omitempty"`
 	GroupID  string             `json:"group_id" bson:"group_id"`
 	Capacity Capacity           `json:"capacity" bson:"capacity"`
 }

--- a/api/internal/pkg/pac-go-server/models/request.go
+++ b/api/internal/pkg/pac-go-server/models/request.go
@@ -3,7 +3,7 @@ package models
 import (
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 type RequestStateType string
@@ -21,7 +21,7 @@ const (
 )
 
 type Request struct {
-	ID             primitive.ObjectID `json:"id" bson:"_id,omitempty"`
+	ID             bson.ObjectID `json:"id" bson:"_id,omitempty"`
 	UserID         string             `json:"user_id" bson:"user_id,omitempty"`
 	Username       string             `json:"username" bson:"-"`
 	Email          string             `json:"email" bson:"-"`

--- a/api/internal/pkg/pac-go-server/services/backend_test.go
+++ b/api/internal/pkg/pac-go-server/services/backend_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/utils"
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/golang/mock/gomock"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -594,8 +594,8 @@ func getResource(apiType string, customValues map[string]interface{}) interface{
 		return []models.Feedback{feedback}
 	case "get-all-maintenance-windows":
 		now := time.Now()
-		objectID1, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
-		objectID2, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439012")
+		objectID1, _ := bson.ObjectIDFromHex("507f1f77bcf86cd799439011") // pragma: allowlist secret
+		objectID2, _ := bson.ObjectIDFromHex("507f1f77bcf86cd799439012") // pragma: allowlist secret
 		window1 := models.MaintenanceWindow{
 			ID:        objectID1,
 			Enabled:   true,
@@ -621,7 +621,7 @@ func getResource(apiType string, customValues map[string]interface{}) interface{
 		return []models.MaintenanceWindow{window1, window2}
 	case "get-maintenance-window-by-id":
 		now := time.Now()
-		objectID, _ := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
+		objectID, _ := bson.ObjectIDFromHex("507f1f77bcf86cd799439011") // pragma: allowlist secret
 		window := models.MaintenanceWindow{
 			ID:        objectID,
 			Enabled:   true,

--- a/api/internal/pkg/pac-go-server/services/group.go
+++ b/api/internal/pkg/pac-go-server/services/group.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/zap"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/client"

--- a/api/internal/pkg/pac-go-server/services/maintenance.go
+++ b/api/internal/pkg/pac-go-server/services/maintenance.go
@@ -10,7 +10,7 @@ import (
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/utils"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.uber.org/zap"
 )
 
@@ -230,7 +230,7 @@ func CreateMaintenanceWindow(c *gin.Context) {
 
 	// Create maintenance window
 	window := &models.MaintenanceWindow{
-		ID:        primitive.NewObjectID(),
+		ID:        bson.NewObjectID(),
 		Enabled:   request.Enabled,
 		StartTime: request.StartTime,
 		EndTime:   request.EndTime,

--- a/api/internal/pkg/pac-go-server/services/quota.go
+++ b/api/internal/pkg/pac-go-server/services/quota.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.uber.org/zap"
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/client"

--- a/api/internal/pkg/pac-go-server/services/tnc.go
+++ b/api/internal/pkg/pac-go-server/services/tnc.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 // GetTermsAndConditionsStatus		godoc


### PR DESCRIPTION
As the mongo driver 1.x is getting deprecated, we had to migrate to v2 version as mentioned here-https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo.
I have tested this by branch deployment in the staging env.