### PR TITLE
Integrate chat support with live WebSocket streaming

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.mod|go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-26T06:43:32Z",
+  "generated_at": "2026-07-09T04:46:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -332,7 +332,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 124,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/api/cmd/pac-go-server/main.go
+++ b/api/cmd/pac-go-server/main.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -16,9 +21,13 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 )
 
-var (
-	servicePort = "8000"
-)
+var servicePort string
+
+// shutdownGrace is the time the server gives active WebSocket sessions and
+// background workers to finish before the process exits.  Long enough for
+// in-flight DB writes and a clean WS close frame; short enough to satisfy
+// most orchestrator restart budgets (Kubernetes default terminationGracePeriodSeconds=30s).
+const shutdownGrace = 10 * time.Second
 
 func initFlags() {
 	flag.StringVar(&servicePort, "port", "8000", "port to run the service on")
@@ -30,19 +39,19 @@ func initFlags() {
 }
 
 func main() {
+	initFlags()
 	logger := log.GetLogger()
 	logger.Info("Starting PAC server...")
-	initFlags()
 
 	logger.Info("Attempting to connect to MongoDB...")
 	db := mongodb.New()
 	if err := db.Connect(); err != nil {
-		panic(err)
+		logger.Fatal("failed to connect to MongoDB", zap.Error(err))
 	}
 
 	defer func() {
 		if err := db.Disconnect(); err != nil {
-			panic(err)
+			logger.Error("failed to disconnect from MongoDB", zap.Error(err))
 		}
 	}()
 	services.SetDB(db)
@@ -51,10 +60,48 @@ func main() {
 	kubeClient := kubernetes.NewClient()
 	services.SetKubeClient(kubeClient)
 
-	logger.Info("Starting service expiry notifier")
-	go services.ExpiryNotification()
+	// workerCtx is cancelled on shutdown to signal background workers to
+	// drain their queues and exit.
+	workerCtx, workerCancel := context.WithCancel(context.Background())
 
-	var appRouter = router.CreateRouter()
-	logger.Info("PAC server is up and running", zap.String("port", servicePort))
-	logger.Fatal("Error encountered while routing", zap.Error(appRouter.Run(":"+servicePort)))
+	logger.Info("Starting service expiry notifier")
+	go services.ExpiryNotification(workerCtx)
+
+	go services.StartAdminReplyWorker(workerCtx)
+
+	srv := &http.Server{
+		Addr:    ":" + servicePort,
+		Handler: router.CreateRouter(),
+	}
+
+	// Start serving in a background goroutine so the main goroutine can block
+	// on the OS signal channel instead.
+	go func() {
+		logger.Info("PAC server is up and running", zap.String("port", servicePort))
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("server error", zap.Error(err))
+		}
+	}()
+
+	// Block until SIGINT or SIGTERM is received.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	sig := <-quit
+	logger.Info("shutdown signal received, draining active connections",
+		zap.String("signal", sig.String()),
+		zap.Duration("grace", shutdownGrace),
+	)
+
+	// Cancel background workers first so they can drain concurrently with the
+	// HTTP server draining its active connections within the grace window.
+	workerCancel()
+
+	// Stop accepting new connections; give existing sessions the grace period.
+	shutCtx, shutCancel := context.WithTimeout(context.Background(), shutdownGrace)
+	defer shutCancel()
+	if err := srv.Shutdown(shutCtx); err != nil {
+		logger.Error("server forced to shut down before grace period expired", zap.Error(err))
+	}
+
+	logger.Info("PAC server exited cleanly")
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.101.0
 	github.com/IBM/vpc-go-sdk v0.87.1
 	github.com/Nerzal/gocloak/v13 v13.9.0
+	github.com/coder/websocket v1.8.15
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-logr/logr v1.4.4
 	github.com/go-playground/validator/v10 v10.30.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -55,6 +55,8 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coredns/corefile-migration v1.0.21 h1:W/DCETrHDiFo0Wj03EyMkaQ9fwsmSgqTCQDHpceaSsE=

--- a/api/internal/pkg/pac-go-server/db/interface.go
+++ b/api/internal/pkg/pac-go-server/db/interface.go
@@ -56,4 +56,14 @@ type DB interface {
 	CreateMaintenanceWindow(window *models.MaintenanceWindow) error
 	UpdateMaintenanceWindow(window *models.MaintenanceWindow) error
 	DeleteMaintenanceWindow(id string, deletedBy string, deletedAt *time.Time) error
+
+	// Chat support operations
+	InsertChatMessage(ctx context.Context, msg *models.ChatMessage) error
+	MarkConversationEnded(ctx context.Context, userID, username string, conversationID int64) error
+	IsConversationEnded(ctx context.Context, userID string, conversationID int64) (bool, error)
+	GetCurrentConversationID(ctx context.Context, userID string) (int64, error)
+	GetNextConversationID(ctx context.Context, userID string) (int64, error)
+	GetChatMessages(ctx context.Context, userID string, conversationID int64) ([]models.ChatMessage, error)
+	GetUserConversations(ctx context.Context, userID string) ([]models.ConversationSummary, error)
+	GetAllConversations(ctx context.Context) ([]models.ConversationSummary, error)
 }

--- a/api/internal/pkg/pac-go-server/db/mock_db_client.go
+++ b/api/internal/pkg/pac-go-server/db/mock_db_client.go
@@ -587,3 +587,121 @@ func (mr *MockDBMockRecorder) WatchEvents(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchEvents", reflect.TypeOf((*MockDB)(nil).WatchEvents), arg0)
 }
+
+// InsertChatMessage mocks base method.
+func (m *MockDB) InsertChatMessage(arg0 context.Context, arg1 *models.ChatMessage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertChatMessage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertChatMessage indicates an expected call of InsertChatMessage.
+func (mr *MockDBMockRecorder) InsertChatMessage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertChatMessage", reflect.TypeOf((*MockDB)(nil).InsertChatMessage), arg0, arg1)
+}
+
+// MarkConversationEnded mocks base method.
+func (m *MockDB) MarkConversationEnded(arg0 context.Context, arg1 string, arg2 string, arg3 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkConversationEnded", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkConversationEnded indicates an expected call of MarkConversationEnded.
+func (mr *MockDBMockRecorder) MarkConversationEnded(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkConversationEnded", reflect.TypeOf((*MockDB)(nil).MarkConversationEnded), arg0, arg1, arg2, arg3)
+}
+
+// IsConversationEnded mocks base method.
+func (m *MockDB) IsConversationEnded(arg0 context.Context, arg1 string, arg2 int64) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsConversationEnded", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsConversationEnded indicates an expected call of IsConversationEnded.
+func (mr *MockDBMockRecorder) IsConversationEnded(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConversationEnded", reflect.TypeOf((*MockDB)(nil).IsConversationEnded), arg0, arg1, arg2)
+}
+
+// GetCurrentConversationID mocks base method.
+func (m *MockDB) GetCurrentConversationID(arg0 context.Context, arg1 string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentConversationID", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentConversationID indicates an expected call of GetCurrentConversationID.
+func (mr *MockDBMockRecorder) GetCurrentConversationID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentConversationID", reflect.TypeOf((*MockDB)(nil).GetCurrentConversationID), arg0, arg1)
+}
+
+// GetNextConversationID mocks base method.
+func (m *MockDB) GetNextConversationID(arg0 context.Context, arg1 string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNextConversationID", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNextConversationID indicates an expected call of GetNextConversationID.
+func (mr *MockDBMockRecorder) GetNextConversationID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextConversationID", reflect.TypeOf((*MockDB)(nil).GetNextConversationID), arg0, arg1)
+}
+
+// GetChatMessages mocks base method.
+func (m *MockDB) GetChatMessages(arg0 context.Context, arg1 string, arg2 int64) ([]models.ChatMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetChatMessages", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]models.ChatMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetChatMessages indicates an expected call of GetChatMessages.
+func (mr *MockDBMockRecorder) GetChatMessages(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChatMessages", reflect.TypeOf((*MockDB)(nil).GetChatMessages), arg0, arg1, arg2)
+}
+
+// GetUserConversations mocks base method.
+func (m *MockDB) GetUserConversations(arg0 context.Context, arg1 string) ([]models.ConversationSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserConversations", arg0, arg1)
+	ret0, _ := ret[0].([]models.ConversationSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserConversations indicates an expected call of GetUserConversations.
+func (mr *MockDBMockRecorder) GetUserConversations(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserConversations", reflect.TypeOf((*MockDB)(nil).GetUserConversations), arg0, arg1)
+}
+
+// GetAllConversations mocks base method.
+func (m *MockDB) GetAllConversations(arg0 context.Context) ([]models.ConversationSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllConversations", arg0)
+	ret0, _ := ret[0].([]models.ConversationSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllConversations indicates an expected call of GetAllConversations.
+func (mr *MockDBMockRecorder) GetAllConversations(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllConversations", reflect.TypeOf((*MockDB)(nil).GetAllConversations), arg0)
+}

--- a/api/internal/pkg/pac-go-server/db/mongodb/chat.go
+++ b/api/internal/pkg/pac-go-server/db/mongodb/chat.go
@@ -1,0 +1,304 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+const chatCollection = "chat_messages"
+
+// BSON field name constants for the chat_messages collection.
+// Using constants prevents silent query failures from typos in field name strings.
+const (
+	fieldUserID         = "user_id"
+	fieldConversationID = "conversation_id"
+	fieldSender         = "sender"
+	fieldMessage        = "message"
+	fieldTimestamp      = "timestamp"
+	fieldUsername       = "username"
+)
+
+// MarkConversationEnded writes a system sentinel message so the ended state
+// survives server restarts and page navigations.
+func (db *MongoDB) MarkConversationEnded(ctx context.Context, userID, username string, conversationID int64) error {
+	sentinel := &models.ChatMessage{
+		ConversationID: conversationID,
+		UserID:         userID,
+		Username:       username,
+		Message:        EndedSentinel,
+		Sender:         models.SenderSystem,
+		Timestamp:      time.Now(),
+	}
+	return db.InsertChatMessage(ctx, sentinel)
+}
+
+// IsConversationEnded returns true if the given conversation has an ended sentinel.
+func (db *MongoDB) IsConversationEnded(ctx context.Context, userID string, conversationID int64) (bool, error) {
+	collection := db.Database.Collection(chatCollection)
+	filter := bson.M{
+		fieldUserID:         userID,
+		fieldConversationID: conversationID,
+		fieldSender:         models.SenderSystem,
+		fieldMessage:        EndedSentinel,
+	}
+	count, err := collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return false, fmt.Errorf("error checking conversation ended: %w", err)
+	}
+	return count > 0, nil
+}
+
+// InsertChatMessage saves a single chat message to the DB.
+// The caller-supplied ctx is used as the parent for the write timeout so that
+// request cancellations (e.g. client disconnect) propagate correctly.
+func (db *MongoDB) InsertChatMessage(ctx context.Context, msg *models.ChatMessage) error {
+	collection := db.Database.Collection(chatCollection)
+	ctxT, cancel := context.WithTimeout(ctx, dbContextTimeout)
+	defer cancel()
+
+	if _, err := collection.InsertOne(ctxT, msg); err != nil {
+		return fmt.Errorf("error inserting chat message: %w", err)
+	}
+	return nil
+}
+
+// GetCurrentConversationID returns the latest conversation ID for a user,
+// or 1 if the user has no messages yet. Unlike GetNextConversationID it does
+// NOT increment — reconnecting always resumes the same conversation.
+//
+// All message senders (user, admin, system) are considered so that a new
+// conversation that only has a system sentinel so far (e.g. the user started
+// a new conv but the server restart happened before the first user message)
+// is still correctly identified as the current conversation.
+func (db *MongoDB) GetCurrentConversationID(ctx context.Context, userID string) (int64, error) {
+	collection := db.Database.Collection(chatCollection)
+
+	opts := options.FindOne().SetSort(bson.D{{Key: fieldConversationID, Value: -1}})
+	filter := bson.M{fieldUserID: userID}
+
+	var result models.ChatMessage
+	err := collection.FindOne(ctx, filter, opts).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 1, nil
+		}
+		return 0, fmt.Errorf("error finding current conversation_id: %w", err)
+	}
+	return result.ConversationID, nil
+}
+
+// GetNextConversationID returns a brand-new conversation ID (latest + 1).
+// Use this only when the user explicitly starts a new conversation.
+func (db *MongoDB) GetNextConversationID(ctx context.Context, userID string) (int64, error) {
+	collection := db.Database.Collection(chatCollection)
+
+	opts := options.FindOne().SetSort(bson.D{{Key: fieldConversationID, Value: -1}})
+	filter := bson.M{fieldUserID: userID}
+
+	var result models.ChatMessage
+	err := collection.FindOne(ctx, filter, opts).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 1, nil
+		}
+		return 0, fmt.Errorf("error finding max conversation_id: %w", err)
+	}
+	return result.ConversationID + 1, nil
+}
+
+// GetChatMessages returns all displayable messages for a user's conversation, oldest first.
+// System sentinel messages (conversation_ended) are excluded; other system messages (e.g. auto-reply) are included.
+func (db *MongoDB) GetChatMessages(ctx context.Context, userID string, conversationID int64) ([]models.ChatMessage, error) {
+	collection := db.Database.Collection(chatCollection)
+
+	filter := bson.M{
+		fieldUserID:         userID,
+		fieldConversationID: conversationID,
+		// Exclude only the ended sentinel; keep system auto-reply messages.
+		"$nor": bson.A{
+			bson.M{fieldSender: models.SenderSystem, fieldMessage: EndedSentinel},
+		},
+	}
+	opts := options.Find().SetSort(bson.D{{Key: fieldTimestamp, Value: 1}})
+
+	cursor, err := collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching chat messages: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var messages []models.ChatMessage
+	if err := cursor.All(ctx, &messages); err != nil {
+		return nil, fmt.Errorf("error decoding chat messages: %w", err)
+	}
+	return messages, nil
+}
+
+// EndedSentinel is the message text written to the DB when a conversation ends.
+// It is used to detect ended conversations without a separate collection.
+const EndedSentinel = "conversation_ended"
+
+// GetUserConversations returns conversation summaries for a single user, ordered by most recent.
+// Each summary includes Ended (true if a system sentinel exists) and FirstMessage (first user text).
+func (db *MongoDB) GetUserConversations(ctx context.Context, userID string) ([]models.ConversationSummary, error) {
+	collection := db.Database.Collection(chatCollection)
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{fieldUserID: userID}}},
+		{
+			{Key: "$sort", Value: bson.D{{Key: fieldTimestamp, Value: 1}}},
+		},
+		{
+			{Key: "$group", Value: bson.D{
+				{Key: "_id", Value: "$" + fieldConversationID},
+				{Key: "message_count", Value: bson.D{{Key: "$sum", Value: 1}}},
+				{Key: "last_message_at", Value: bson.D{{Key: "$max", Value: "$" + fieldTimestamp}}},
+				{Key: fieldUsername, Value: bson.D{{Key: "$first", Value: "$" + fieldUsername}}},
+				// Collect all (sender, message) pairs to derive ended + first_message.
+				{Key: "msgs", Value: bson.D{{Key: "$push", Value: bson.D{
+					{Key: fieldSender, Value: "$" + fieldSender},
+					{Key: fieldMessage, Value: "$" + fieldMessage},
+				}}}},
+			}},
+		},
+		{{Key: "$sort", Value: bson.D{{Key: "last_message_at", Value: -1}}}},
+	}
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("error aggregating user conversations: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	type msgPair struct {
+		Sender  models.MessageSender `bson:"sender"`
+		Message string               `bson:"message"`
+	}
+	type rawSummary struct {
+		ConversationID int64     `bson:"_id"`
+		MessageCount   int64     `bson:"message_count"`
+		LastMessageAt  time.Time `bson:"last_message_at"`
+		Username       string    `bson:"username"`
+		Msgs           []msgPair `bson:"msgs"`
+	}
+
+	var raw []rawSummary
+	if err := cursor.All(ctx, &raw); err != nil {
+		return nil, fmt.Errorf("error decoding user conversations: %w", err)
+	}
+
+	summaries := make([]models.ConversationSummary, 0, len(raw))
+	for _, r := range raw {
+		ended := false
+		firstMsg := ""
+		for _, m := range r.Msgs {
+			if m.Sender == models.SenderSystem && m.Message == EndedSentinel {
+				ended = true
+			}
+			if firstMsg == "" && m.Sender == models.SenderUser {
+				firstMsg = m.Message
+			}
+		}
+		summaries = append(summaries, models.ConversationSummary{
+			ConversationID: r.ConversationID,
+			UserID:         userID,
+			Username:       r.Username,
+			MessageCount:   r.MessageCount,
+			LastMessageAt:  r.LastMessageAt,
+			Ended:          ended,
+			FirstMessage:   firstMsg,
+		})
+	}
+	return summaries, nil
+}
+
+// GetAllConversations returns one summary row per unique (user_id, conversation_id) pair,
+// ordered by the most recent activity, including ended status.
+func (db *MongoDB) GetAllConversations(ctx context.Context) ([]models.ConversationSummary, error) {
+	collection := db.Database.Collection(chatCollection)
+
+	// Pipeline overview — runs entirely inside MongoDB, no per-row round-trips:
+	//
+	// Stage 1 — $group by (user_id, conversation_id):
+	//   • message_count  — total number of messages in the conversation.
+	//   • last_message_at — timestamp of the most recent message; used for sort.
+	//   • username       — first username seen (all rows share the same value).
+	//   • senders        — distinct (sender, message) pairs collected via
+	//                      $addToSet.  This is NOT the full message history;
+	//                      it is a small deduplicated set used only to check
+	//                      whether the ended sentinel is present.  Message text
+	//                      is loaded separately by GetAdminConversationMessages
+	//                      when the admin opens a specific conversation.
+	//
+	// Stage 2 — $sort by last_message_at descending (newest conversation first).
+	pipeline := mongo.Pipeline{
+		{
+			{Key: "$group", Value: bson.D{
+				{Key: "_id", Value: bson.D{
+					{Key: fieldUserID, Value: "$" + fieldUserID},
+					{Key: fieldConversationID, Value: "$" + fieldConversationID},
+				}},
+				{Key: "message_count", Value: bson.D{{Key: "$sum", Value: 1}}},
+				{Key: "last_message_at", Value: bson.D{{Key: "$max", Value: "$" + fieldTimestamp}}},
+				{Key: fieldUsername, Value: bson.D{{Key: "$first", Value: "$" + fieldUsername}}},
+				{Key: "senders", Value: bson.D{{Key: "$addToSet", Value: bson.D{
+					{Key: fieldSender, Value: "$" + fieldSender},
+					{Key: fieldMessage, Value: "$" + fieldMessage},
+				}}}},
+			}},
+		},
+		{{Key: "$sort", Value: bson.D{{Key: "last_message_at", Value: -1}}}},
+	}
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("error aggregating conversations: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	type senderPair struct {
+		Sender  models.MessageSender `bson:"sender"`
+		Message string               `bson:"message"`
+	}
+	type rawSummary struct {
+		ID struct {
+			UserID         string `bson:"user_id"`
+			ConversationID int64  `bson:"conversation_id"`
+		} `bson:"_id"`
+		MessageCount  int64        `bson:"message_count"`
+		LastMessageAt time.Time    `bson:"last_message_at"`
+		Username      string       `bson:"username"`
+		Senders       []senderPair `bson:"senders"`
+	}
+
+	var raw []rawSummary
+	if err := cursor.All(ctx, &raw); err != nil {
+		return nil, fmt.Errorf("error decoding conversations: %w", err)
+	}
+
+	summaries := make([]models.ConversationSummary, 0, len(raw))
+	for _, r := range raw {
+		ended := false
+		for _, s := range r.Senders {
+			if s.Sender == models.SenderSystem && s.Message == EndedSentinel {
+				ended = true
+				break
+			}
+		}
+		summaries = append(summaries, models.ConversationSummary{
+			ConversationID: r.ID.ConversationID,
+			UserID:         r.ID.UserID,
+			Username:       r.Username,
+			MessageCount:   r.MessageCount,
+			LastMessageAt:  r.LastMessageAt,
+			Ended:          ended,
+		})
+	}
+	return summaries, nil
+}

--- a/api/internal/pkg/pac-go-server/models/chat.go
+++ b/api/internal/pkg/pac-go-server/models/chat.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// MessageSender identifies who authored a chat message.
+type MessageSender string
+
+// Sender constants for ChatMessage.Sender.
+const (
+	SenderUser   MessageSender = "user"
+	SenderAdmin  MessageSender = "admin"
+	SenderSystem MessageSender = "system"
+)
+
+// ChatMessage represents a single message in a support conversation.
+type ChatMessage struct {
+	ID             bson.ObjectID `json:"id" bson:"_id,omitempty"`
+	ConversationID int64         `json:"conversation_id" bson:"conversation_id"`
+	UserID         string        `json:"user_id" bson:"user_id"`
+	Username       string        `json:"username" bson:"username"` // preferred_username from Keycloak
+	Message        string        `json:"message" bson:"message"`
+	Sender         MessageSender `json:"sender" bson:"sender"`
+	Timestamp      time.Time     `json:"timestamp" bson:"timestamp"`
+}
+
+// ConversationSummary is returned to list conversations.
+type ConversationSummary struct {
+	ConversationID int64     `json:"conversation_id" bson:"conversation_id"`
+	UserID         string    `json:"user_id" bson:"user_id"`
+	Username       string    `json:"username"` // preferred_username, for display
+	MessageCount   int64     `json:"message_count"`
+	LastMessageAt  time.Time `json:"last_message_at" bson:"last_message_at"`
+	Ended          bool      `json:"ended"`
+	FirstMessage   string    `json:"first_message"` // preview label for the user sidebar
+}

--- a/api/internal/pkg/pac-go-server/router/middleware.go
+++ b/api/internal/pkg/pac-go-server/router/middleware.go
@@ -7,11 +7,34 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	pacClient "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/client"
+	log "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/logger"
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
 	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/utils"
 )
+
+// InjectTokenFromQuery promotes a ?token= query parameter to an
+// "Authorization: Bearer <token>" header. This is needed for WebSocket
+// connections because browsers cannot set custom headers on the WS upgrade
+// request. Must be placed before the Keycloak auth middlewares.
+func InjectTokenFromQuery(c *gin.Context) {
+	token := c.Query("token")
+	if token != "" && c.GetHeader("Authorization") == "" {
+		c.Request.Header.Set("Authorization", "Bearer "+token)
+		log.GetLogger().Debug("InjectTokenFromQuery: set Authorization header from ?token=",
+			zap.String("path", c.Request.URL.Path),
+		)
+	} else {
+		log.GetLogger().Warn("InjectTokenFromQuery: skipped",
+			zap.String("path", c.Request.URL.Path),
+			zap.Bool("token_present", token != ""),
+			zap.Bool("auth_header_present", c.GetHeader("Authorization") != ""),
+		)
+	}
+	c.Next()
+}
 
 func AllowAdminOnly(c *gin.Context) {
 	config := pacClient.GetConfigFromContext(c.Request.Context())

--- a/api/internal/pkg/pac-go-server/router/router.go
+++ b/api/internal/pkg/pac-go-server/router/router.go
@@ -42,6 +42,7 @@ func CreateRouter() *gin.Engine {
 	}
 
 	authorized := router.Group("/api/v1")
+	authorized.Use(gin.Logger())
 	authorized.Use(ginkeycloak.Auth(ginkeycloak.AuthCheck(), ginkeycloak.KeycloakConfig{
 		Url:   hostname,
 		Realm: realm,
@@ -132,6 +133,37 @@ func CreateRouter() *gin.Engine {
 
 	// maintenance notification related endpoints
 	authorized.GET("/maintenance", services.GetMaintenanceWindows)
+
+	// chat support — user-facing REST endpoints (own conversations + messages)
+	authorized.GET("/conversations", services.GetUserConversations)
+	authorized.GET("/conversations/:conv_id/messages", services.GetUserConversationMessages)
+
+	// chat support — WebSocket endpoint for users.
+	// InjectTokenFromQuery MUST be first: browsers cannot set custom headers on
+	// a WS upgrade request, so the JWT arrives as ?token= and must be promoted
+	// to an Authorization header before the Keycloak middlewares run.
+	// All three middlewares run before HandleChatWebSocket is entered, so they
+	// only ever write HTTP error responses — never after the connection is
+	// hijacked.
+	wsGroup := router.Group("/api/v1")
+	wsGroup.Use(InjectTokenFromQuery)
+	wsGroup.Use(ginkeycloak.Auth(ginkeycloak.AuthCheck(), ginkeycloak.KeycloakConfig{
+		Url:   hostname,
+		Realm: realm,
+	}))
+	wsGroup.Use(RetrospectKeycloakToken)
+	wsGroup.GET("/chat", services.HandleChatWebSocket)
+	// Admin watch WebSockets: reuse the same InjectTokenFromQuery + auth chain.
+	wsGroup.Use(AllowAdminOnly)
+	wsGroup.GET("/admin/conversations/:user_id/:conv_id/ws", services.AdminWatchConversation)
+	// Single broadcast WS — admin subscribes once to get unread indicators for all convs.
+	wsGroup.GET("/admin/watch", services.AdminWatchAll)
+
+	// chat support — REST endpoints for admins
+	authorizedAdmin.GET("/admin/conversations", services.GetAdminConversations)
+	authorizedAdmin.GET("/admin/conversations/:user_id/:conv_id/messages", services.GetAdminConversationMessages)
+	authorizedAdmin.POST("/admin/conversations/:user_id/:conv_id/reply", services.AdminReply)
+	authorizedAdmin.POST("/admin/conversations/:user_id/:conv_id/end", services.AdminEndConversation)
 
 	return router
 }

--- a/api/internal/pkg/pac-go-server/services/chat.go
+++ b/api/internal/pkg/pac-go-server/services/chat.go
@@ -1,0 +1,856 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+
+	pacClient "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/client"
+	log "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/logger"
+	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
+)
+
+// wsWriteTimeout is the maximum time allowed for a single WebSocket write.
+// Without a deadline, a zombie client (network dropped but TCP not yet closed)
+// will cause wsjson.Write to block indefinitely, leaking the goroutine until
+// the OS TCP keepalive eventually fires (minutes to hours).
+const wsWriteTimeout = 10 * time.Second
+
+// wsWrite wraps wsjson.Write with a per-call timeout derived from the
+// session context.  Using the session ctx (not a fresh Background ctx) means
+// that if the session is already cancelled the write returns immediately.
+func wsWrite(ctx context.Context, conn *websocket.Conn, v interface{}) error {
+	wctx, cancel := context.WithTimeout(ctx, wsWriteTimeout)
+	defer cancel()
+	return wsjson.Write(wctx, conn, v)
+}
+
+// HandleChatWebSocket upgrades the connection to WebSocket and handles real-time
+// chat messages for the authenticated user.
+func HandleChatWebSocket(c *gin.Context) {
+	logger := log.GetLogger()
+
+	// Auth is already done by the middleware chain (InjectTokenFromQuery →
+	// ginkeycloak.Auth → RetrospectKeycloakToken). Read userid before the
+	// upgrade since c.Request.Context() is only valid until the handler returns.
+	userID, _ := c.Request.Context().Value("userid").(string)
+	username, _ := c.Request.Context().Value("username").(string)
+
+	// coder/websocket calls WriteHeaderNow() on Gin's writer before Hijack(),
+	// which sets Written()=true and causes Gin's Hijack() guard to reject it.
+	// Unwrap one level to get the raw net/http ResponseWriter, bypassing that
+	// check. coder/websocket's own hijacker() loop still finds the socket.
+	type unwrapper interface{ Unwrap() http.ResponseWriter }
+	rw := http.ResponseWriter(c.Writer)
+	if u, ok := c.Writer.(unwrapper); ok {
+		rw = u.Unwrap()
+	}
+	conn, err := websocket.Accept(rw, c.Request, &websocket.AcceptOptions{
+		OriginPatterns: []string{"*"},
+	})
+	if err != nil {
+		logger.Error("websocket upgrade failed", zap.Error(err))
+		return
+	}
+
+	// Mark Gin's writer as written so Recovery/WriteHeaderNow do not attempt
+	// to write on the hijacked connection when the middleware chain unwinds.
+	c.Writer.WriteHeaderNow()
+
+	// Run the WebSocket loop in a goroutine and return immediately from the
+	// handler. This is the key fix for the EOF-on-first-read bug:
+	//
+	// RetrospectKeycloakToken calls c.Next() which runs this handler inline.
+	// If the handler blocks in the read loop, everything is fine — until the
+	// loop exits and the middleware chain unwinds. net/http then calls
+	// finishRequest() which closes the TCP socket, killing the connection.
+	//
+	// By returning immediately, the middleware chain unwinds while the
+	// goroutine owns the already-hijacked conn. net/http sees Written()=true
+	// and does not attempt to close or write to the connection.
+	go func() {
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		serveChat(conn, userID, username, logger)
+	}()
+}
+
+// chatSession holds the mutable per-connection state shared across the helper
+// functions that make up the WebSocket serve loop.
+type chatSession struct {
+	conn     *websocket.Conn
+	ctx      context.Context
+	userID   string
+	username string
+	logger   *zap.Logger
+
+	conversationID int64
+	convEnded      bool
+	// history tracks whether the current conversation already has messages.
+	// It is non-nil (even if empty) after initChatSession, and is set to a
+	// non-empty sentinel after the first user message so the auto-reply is
+	// never sent twice for the same conversation.
+	history []models.ChatMessage
+
+	// incomingFromAdminCh receives hub messages pushed to this user.
+	// unsubFromAdmin must be called on session teardown.
+	incomingFromAdminCh chan hubMessage
+	unsubFromAdmin      func()
+}
+
+// initChatSession loads conversation state from the DB, sends the hello frame,
+// and subscribes to the hub.  Returns an error if the session cannot start
+// (e.g. DB failure or failed hello write); the caller should return immediately.
+func initChatSession(ctx context.Context, conn *websocket.Conn, userID, username string, logger *zap.Logger) (*chatSession, error) {
+	conversationID, err := dbCon.GetCurrentConversationID(ctx, userID)
+	if err != nil {
+		logger.Error("failed to get conversation ID", zap.Error(err))
+		_ = wsWrite(ctx, conn, gin.H{"error": "failed to initialize conversation"})
+		return nil, err
+	}
+
+	convEnded, err := dbCon.IsConversationEnded(ctx, userID, conversationID)
+	if err != nil {
+		logger.Warn("failed to check conversation ended state", zap.Error(err))
+		// non-fatal: treat as not ended
+	}
+
+	history, err := dbCon.GetChatMessages(ctx, userID, conversationID)
+	if err != nil {
+		logger.Error("failed to load chat history", zap.Error(err))
+		history = nil
+	}
+
+	type msgFrame struct {
+		ID             string               `json:"id"`
+		ConversationID int64                `json:"conversation_id"`
+		Sender         models.MessageSender `json:"sender"`
+		Message        string               `json:"message"`
+		Timestamp      string               `json:"timestamp"`
+	}
+	historyFrames := make([]msgFrame, 0, len(history))
+	for _, m := range history {
+		historyFrames = append(historyFrames, msgFrame{
+			ID:             m.ID.Hex(),
+			ConversationID: m.ConversationID,
+			Sender:         m.Sender,
+			Message:        m.Message,
+			Timestamp:      m.Timestamp.Format(time.RFC3339),
+		})
+	}
+
+	hello := map[string]interface{}{
+		"type":            "hello",
+		"conversation_id": conversationID,
+		"ended":           convEnded,
+		"history":         historyFrames,
+	}
+	if err := wsWrite(ctx, conn, hello); err != nil {
+		logger.Error("failed to send hello frame", zap.Error(err))
+		return nil, err
+	}
+
+	logger.Info("conversation resumed",
+		zap.String("userID", userID),
+		zap.Int64("conversationID", conversationID),
+		zap.Int("history_len", len(history)))
+
+	// incomingFromAdminCh is the channel through which the hub delivers admin
+	// and system messages to this session.  AdminReply and AdminEndConversation
+	// publish to the hub under the userID key; the hub fans out to this channel
+	// so the select loop can push the message to the connected client over
+	// WebSocket without polling.  Buffered (16) so a slow WebSocket write does
+	// not block the HTTP handler that called hub.publish.
+	incomingFromAdminCh := make(chan hubMessage, 16)
+	unsubFromAdmin := hub.subscribe(userID, incomingFromAdminCh)
+
+	return &chatSession{
+		conn:                conn,
+		ctx:                 ctx,
+		userID:              userID,
+		username:            username,
+		logger:              logger,
+		conversationID:      conversationID,
+		convEnded:           convEnded,
+		history:             history,
+		incomingFromAdminCh: incomingFromAdminCh,
+		unsubFromAdmin:      unsubFromAdmin,
+	}, nil
+}
+
+// handleEndConversation processes the "end_conversation" action frame.
+// Returns true if the WebSocket connection must be closed (fatal write error).
+func (s *chatSession) handleEndConversation() (fatal bool) {
+	if s.convEnded {
+		return false // already ended — ignore duplicate
+	}
+	s.convEnded = true
+
+	// Persist the ended sentinel so the status survives reconnects.
+	if err := dbCon.MarkConversationEnded(s.ctx, s.userID, s.username, s.conversationID); err != nil {
+		s.logger.Error("failed to mark conversation ended", zap.Error(err))
+	}
+
+	// Notify any admin watching this conversation.
+	hub.publish(userToAdminKey(s.userID, s.conversationID), hubMessage{
+		ConversationID: s.conversationID,
+		Sender:         models.SenderSystem,
+		Message:        "conversation_ended",
+	})
+
+	frame := map[string]interface{}{
+		"type":            "ended",
+		"conversation_id": s.conversationID,
+	}
+	if err := wsWrite(s.ctx, s.conn, frame); err != nil {
+		s.logger.Error("failed to send ended frame", zap.Error(err))
+		return true
+	}
+	s.logger.Info("conversation ended by user",
+		zap.String("userID", s.userID),
+		zap.Int64("conversationID", s.conversationID))
+	return false
+}
+
+// handleUserMessage saves the user message, publishes it to the hub, echoes it
+// back, and fires the one-time auto-reply on the first message of each conversation.
+// Returns true if the WebSocket connection must be closed (fatal write error).
+// Returns (false, true) as (fatal, skip) when a non-fatal error means the
+// message should be skipped (e.g. DB failure getting next conv ID).
+func (s *chatSession) handleUserMessage(msg string) (fatal bool, skip bool) {
+	// If the previous conversation was ended, lazily promote to a new conv ID
+	// now that there is real content to save.
+	isNewConv := false
+	if s.convEnded {
+		newID, err := dbCon.GetNextConversationID(s.ctx, s.userID)
+		if err != nil {
+			s.logger.Error("failed to get next conversation ID", zap.Error(err))
+			_ = wsWrite(s.ctx, s.conn, gin.H{"error": "failed to start new conversation"})
+			return false, true
+		}
+		s.conversationID = newID
+		s.convEnded = false
+		isNewConv = true
+
+		// Re-subscribe so hub messages for the new conv reach this session.
+		s.unsubFromAdmin()
+		s.incomingFromAdminCh = make(chan hubMessage, 16)
+		s.unsubFromAdmin = hub.subscribe(s.userID, s.incomingFromAdminCh)
+	}
+
+	// isFirstMessage is true for the very first message of each conversation:
+	// either a brand-new conv (isNewConv) or the opening message of conv 1.
+	isFirstMessage := isNewConv || len(s.history) == 0
+
+	userMsg := &models.ChatMessage{
+		ConversationID: s.conversationID,
+		UserID:         s.userID,
+		Username:       s.username,
+		Message:        msg,
+		Sender:         models.SenderUser,
+		Timestamp:      time.Now(),
+	}
+	// DB insert is synchronous: we echo only after persistence is confirmed.
+	if err := dbCon.InsertChatMessage(s.ctx, userMsg); err != nil {
+		s.logger.Error("failed to save user message", zap.Error(err))
+		_ = wsWrite(s.ctx, s.conn, gin.H{"error": "failed to save message"})
+		return false, true
+	}
+	// Mark history non-empty so the auto-reply is not re-triggered.
+	if isFirstMessage {
+		s.history = []models.ChatMessage{{}}
+	}
+
+	// Publish to any admin watching this conversation and to the broadcast key.
+	hubMsg := hubMessage{
+		ConversationID: s.conversationID,
+		UserID:         s.userID,
+		Sender:         models.SenderUser,
+		Message:        userMsg.Message,
+		Timestamp:      userMsg.Timestamp.Format(time.RFC3339),
+	}
+	hub.publish(userToAdminKey(s.userID, s.conversationID), hubMsg)
+	hub.publish(adminBroadcastKey, hubMsg)
+
+	echo := map[string]interface{}{
+		"conversation_id": s.conversationID,
+		"message":         userMsg.Message,
+		"sender":          models.SenderUser,
+		"timestamp":       userMsg.Timestamp.Format(time.RFC3339),
+	}
+	if err := wsWrite(s.ctx, s.conn, echo); err != nil {
+		s.logger.Error("failed to send echo", zap.Error(err))
+		return true, false
+	}
+
+	if isFirstMessage {
+		if fatal := s.sendAutoReply(); fatal {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+// sendAutoReply saves and echoes the one-time automated system reply sent at
+// the start of every new conversation.
+// Returns true if the WebSocket connection must be closed (fatal write error).
+func (s *chatSession) sendAutoReply() (fatal bool) {
+	const autoReplyText = "Thanks for reaching out! An admin will reply within 48 hours. " +
+		"In the meantime, feel free to browse our FAQ for quick answers: " +
+		"https://github.com/IBM/power-access-cloud/blob/main/support/docs/FAQ.md"
+
+	autoReply := &models.ChatMessage{
+		ConversationID: s.conversationID,
+		UserID:         s.userID,
+		Username:       s.username,
+		Message:        autoReplyText,
+		Sender:         models.SenderSystem,
+		Timestamp:      time.Now(),
+	}
+	if err := dbCon.InsertChatMessage(s.ctx, autoReply); err != nil {
+		s.logger.Error("failed to save auto-reply", zap.Error(err))
+		return false // non-fatal: user message was already saved and echoed
+	}
+	frame := map[string]interface{}{
+		"conversation_id": s.conversationID,
+		"message":         autoReply.Message,
+		"sender":          models.SenderSystem,
+		"timestamp":       autoReply.Timestamp.Format(time.RFC3339),
+	}
+	if err := wsWrite(s.ctx, s.conn, frame); err != nil {
+		s.logger.Error("failed to send auto-reply frame", zap.Error(err))
+		return true
+	}
+	return false
+}
+
+// handleAdminMessage pushes an incoming hub message (admin reply or remote end)
+// to the connected user.
+// Returns true if the WebSocket connection must be closed (fatal write error).
+func (s *chatSession) handleAdminMessage(adminMsg hubMessage) (fatal bool) {
+	// "conversation_ended" is a system signal, not a display message.
+	if adminMsg.Message == "conversation_ended" {
+		// Mark the session as ended so the next user message correctly
+		// triggers a new conversation ID instead of saving to the old one.
+		s.convEnded = true
+		frame := map[string]interface{}{
+			"type":            "ended",
+			"conversation_id": adminMsg.ConversationID,
+		}
+		if err := wsWrite(s.ctx, s.conn, frame); err != nil {
+			s.logger.Error("failed to send ended frame to user", zap.Error(err))
+			return true
+		}
+		return false
+	}
+	frame := map[string]interface{}{
+		"conversation_id": adminMsg.ConversationID,
+		"sender":          adminMsg.Sender,
+		"message":         adminMsg.Message,
+		"timestamp":       adminMsg.Timestamp,
+	}
+	if err := wsWrite(s.ctx, s.conn, frame); err != nil {
+		s.logger.Error("failed to send admin message", zap.Error(err))
+		return true
+	}
+	return false
+}
+
+// serveChat runs the full WebSocket session for one connected user.
+func serveChat(conn *websocket.Conn, userID, username string, logger *zap.Logger) {
+	// Use a cancellable context tied to the connection lifetime.
+	// When the client disconnects (or the server closes the conn), cancel
+	// unblocks any in-flight wsjson.Read/Write immediately — no goroutine leak.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, err := initChatSession(ctx, conn, userID, username, logger)
+	if err != nil {
+		return
+	}
+	defer session.unsubFromAdmin()
+
+	// A single persistent reader goroutine feeds all incoming client frames
+	// into readCh.  Starting it once (rather than once per loop iteration)
+	// means there is never more than one outstanding wsjson.Read at a time,
+	// so no goroutines are leaked when the adminCh or ctx.Done case fires.
+	type readResult struct {
+		msg    string
+		action string
+		err    error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		for {
+			var incoming struct {
+				Message string `json:"message"`
+				Action  string `json:"action"`
+			}
+			err := wsjson.Read(ctx, conn, &incoming)
+			readCh <- readResult{msg: incoming.Message, action: incoming.Action, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case res := <-readCh:
+			if res.err != nil {
+				status := websocket.CloseStatus(res.err)
+				if status == websocket.StatusNormalClosure || status == websocket.StatusGoingAway {
+					logger.Info("websocket closed", zap.String("userID", userID))
+				} else {
+					logger.Error("websocket read error", zap.Error(res.err))
+				}
+				return
+			}
+
+			if res.action == "end_conversation" {
+				if fatal := session.handleEndConversation(); fatal {
+					return
+				}
+				continue
+			}
+
+			if res.msg == "" {
+				continue
+			}
+
+			if fatal, skip := session.handleUserMessage(res.msg); fatal || skip {
+				if fatal {
+					return
+				}
+				continue
+			}
+
+		case adminMsg := <-session.incomingFromAdminCh:
+			if fatal := session.handleAdminMessage(adminMsg); fatal {
+				return
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// GetUserConversations returns the list of the calling user's own conversations.
+func GetUserConversations(c *gin.Context) {
+	logger := log.GetLogger()
+	userID, _ := c.Request.Context().Value("userid").(string)
+	summaries, err := dbCon.GetUserConversations(c.Request.Context(), userID)
+	if err != nil {
+		logger.Error("failed to get user conversations", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"conversations": summaries})
+}
+
+// GetUserConversationMessages returns messages for one of the calling user's own conversations.
+func GetUserConversationMessages(c *gin.Context) {
+	logger := log.GetLogger()
+	userID, _ := c.Request.Context().Value("userid").(string)
+	convIDStr := c.Param("conv_id")
+
+	convID, err := strconv.ParseInt(convIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+		return
+	}
+
+	messages, err := dbCon.GetChatMessages(c.Request.Context(), userID, convID)
+	if err != nil {
+		logger.Error("failed to get user conversation messages", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"messages": messages})
+}
+
+// GetAdminConversations returns a list of all user conversations for the admin panel.
+// For any conversation whose username was not stored in the DB (legacy data), the
+// username is resolved from Keycloak by userID and backfilled in the response.
+func GetAdminConversations(c *gin.Context) {
+	logger := log.GetLogger()
+	summaries, err := dbCon.GetAllConversations(c.Request.Context())
+	if err != nil {
+		logger.Error("failed to get conversations", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Collect unique userIDs that are missing a username (legacy messages).
+	missing := map[string]struct{}{}
+	for _, s := range summaries {
+		if s.Username == "" {
+			missing[s.UserID] = struct{}{}
+		}
+	}
+
+	if len(missing) > 0 {
+		config := pacClient.GetConfigFromContext(c.Request.Context())
+		kc := pacClient.NewKeyCloakClient(config, c.Request.Context())
+		resolved := make(map[string]string, len(missing))
+		for uid := range missing {
+			user, err := kc.GetUser(uid)
+			if err != nil {
+				logger.Warn("could not resolve username from Keycloak", zap.String("userID", uid), zap.Error(err))
+				resolved[uid] = uid // fall back to raw UUID
+				continue
+			}
+			if user.Username != nil {
+				resolved[uid] = *user.Username
+			} else {
+				resolved[uid] = uid
+			}
+		}
+		for i := range summaries {
+			if summaries[i].Username == "" {
+				summaries[i].Username = resolved[summaries[i].UserID]
+			}
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"conversations": summaries})
+}
+
+// GetAdminConversationMessages returns all messages for a specific conversation.
+func GetAdminConversationMessages(c *gin.Context) {
+	logger := log.GetLogger()
+	userID := c.Param("user_id")
+	convIDStr := c.Param("conv_id")
+
+	convID, err := strconv.ParseInt(convIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+		return
+	}
+
+	messages, err := dbCon.GetChatMessages(c.Request.Context(), userID, convID)
+	if err != nil {
+		logger.Error("failed to get messages", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"messages": messages})
+}
+
+// adminReplyWorker is a package-level buffered channel that decouples the
+// AdminReply HTTP handler from the MongoDB write.  The handler enqueues the
+// fully-constructed ChatMessage and returns HTTP 202 immediately; a single
+// background goroutine drains the queue and persists each message.
+//
+// Buffer size 256: in the worst case (DB temporarily slow) this absorbs a
+// burst of 256 admin replies before the handler starts blocking callers.
+// If the channel is full the handler falls back to a synchronous write so
+// that no reply is ever silently lost.
+var adminReplyQueue = make(chan *models.ChatMessage, 256)
+
+// StartAdminReplyWorker drains adminReplyQueue and persists each message to
+// MongoDB.  It must be started once from main() before the HTTP server begins
+// accepting requests.  It exits when ctx is cancelled (server shutdown).
+func StartAdminReplyWorker(ctx context.Context) {
+	logger := log.GetLogger()
+	for {
+		select {
+		case msg := <-adminReplyQueue:
+			if err := dbCon.InsertChatMessage(ctx, msg); err != nil {
+				logger.Error("adminReplyWorker: failed to persist reply",
+					zap.String("userID", msg.UserID),
+					zap.Int64("conversationID", msg.ConversationID),
+					zap.Error(err),
+				)
+			}
+		case <-ctx.Done():
+			// Drain any remaining items before exiting so in-flight replies
+			// are not lost during a graceful shutdown.
+			for {
+				select {
+				case msg := <-adminReplyQueue:
+					if err := dbCon.InsertChatMessage(context.Background(), msg); err != nil {
+						logger.Error("adminReplyWorker: shutdown drain failed",
+							zap.String("userID", msg.UserID),
+							zap.Error(err),
+						)
+					}
+				default:
+					logger.Info("adminReplyWorker: queue drained, exiting")
+					return
+				}
+			}
+		}
+	}
+}
+
+// AdminReply posts an admin reply into an existing conversation.
+func AdminReply(c *gin.Context) {
+	logger := log.GetLogger()
+
+	adminID, ok := c.Request.Context().Value("userid").(string)
+	if !ok || adminID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	userID := c.Param("user_id")
+	convIDStr := c.Param("conv_id")
+	convID, err := strconv.ParseInt(convIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+		return
+	}
+
+	var body struct {
+		Message string `json:"message" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid body: %s", err.Error())})
+		return
+	}
+
+	msg := &models.ChatMessage{
+		ConversationID: convID,
+		UserID:         userID,
+		Message:        body.Message,
+		Sender:         models.SenderAdmin,
+		Timestamp:      time.Now(),
+	}
+
+	// Attempt to enqueue the DB write for the background worker.
+	// If the queue is full (worker backlogged), fall back to a synchronous
+	// write so the reply is never silently dropped.
+	select {
+	case adminReplyQueue <- msg:
+		// enqueued — worker will persist asynchronously
+	default:
+		logger.Warn("adminReplyQueue full, falling back to synchronous write",
+			zap.String("userID", userID),
+			zap.Int64("conversationID", convID),
+		)
+		if err := dbCon.InsertChatMessage(c.Request.Context(), msg); err != nil {
+			logger.Error("failed to save admin reply", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	// Push the reply to the user's live WebSocket session (if connected).
+	hub.publish(userID, hubMessage{
+		ConversationID: convID,
+		Sender:         models.SenderAdmin,
+		Message:        body.Message,
+		Timestamp:      msg.Timestamp.Format(time.RFC3339),
+	})
+
+	// Also push to every admin watching this conversation so all admin UIs
+	// see the new message in real time (including the sender's own tab).
+	hub.publish(userToAdminKey(userID, convID), hubMessage{
+		ConversationID: convID,
+		Sender:         models.SenderAdmin,
+		Message:        body.Message,
+		Timestamp:      msg.Timestamp.Format(time.RFC3339),
+	})
+
+	logger.Info("admin reply enqueued",
+		zap.String("adminID", adminID),
+		zap.String("targetUserID", userID),
+		zap.Int64("conversationID", convID))
+
+	c.JSON(http.StatusCreated, gin.H{"message": "reply sent"})
+}
+
+// AdminEndConversation lets an admin close a conversation on behalf of the user.
+// It notifies the user's live WebSocket session via the hub so the user's UI
+// transitions to a fresh conversation immediately.
+func AdminEndConversation(c *gin.Context) {
+	logger := log.GetLogger()
+
+	userID := c.Param("user_id")
+	convIDStr := c.Param("conv_id")
+	convID, err := strconv.ParseInt(convIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+		return
+	}
+
+	adminUsername, _ := c.Request.Context().Value("username").(string)
+	_ = adminUsername // username stored on the user's messages, not the admin's
+
+	// Persist the ended sentinel so the status survives reconnects.
+	if err := dbCon.MarkConversationEnded(c.Request.Context(), userID, "", convID); err != nil {
+		logger.Error("failed to mark conversation ended in DB", zap.Error(err))
+		// Non-fatal: still notify the user and return success.
+	}
+
+	// Push an "ended" signal to the user's live WebSocket (if connected).
+	hub.publish(userID, hubMessage{
+		ConversationID: convID,
+		Sender:         models.SenderSystem,
+		Message:        "conversation_ended",
+	})
+
+	logger.Info("admin ended conversation",
+		zap.String("userID", userID),
+		zap.Int64("convID", convID))
+
+	c.JSON(http.StatusOK, gin.H{"message": "conversation ended"})
+}
+
+// AdminWatchConversation upgrades an admin request to a WebSocket and streams
+// new user messages for the specified conversation in real time.
+// The admin opens this connection after selecting a conversation; from that
+// point on, every message the user sends is forwarded here immediately without
+// polling.
+func AdminWatchConversation(c *gin.Context) {
+	logger := log.GetLogger()
+
+	userID := c.Param("user_id")
+	convIDStr := c.Param("conv_id")
+	convID, err := strconv.ParseInt(convIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+		return
+	}
+
+	type unwrapper interface{ Unwrap() http.ResponseWriter }
+	rw := http.ResponseWriter(c.Writer)
+	if u, ok := c.Writer.(unwrapper); ok {
+		rw = u.Unwrap()
+	}
+	conn, err := websocket.Accept(rw, c.Request, &websocket.AcceptOptions{
+		OriginPatterns: []string{"*"},
+	})
+	if err != nil {
+		logger.Error("admin watch: websocket upgrade failed", zap.Error(err))
+		return
+	}
+	c.Writer.WriteHeaderNow()
+
+	go func() {
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// incomingFromUserCh receives messages published by serveChat for this conversation.
+		incomingFromUserCh := make(chan hubMessage, 16)
+		unsubFromUser := hub.subscribe(userToAdminKey(userID, convID), incomingFromUserCh)
+		defer unsubFromUser()
+
+		logger.Info("admin watching conversation",
+			zap.String("userID", userID),
+			zap.Int64("convID", convID))
+
+		// Drain the WebSocket read side in a separate goroutine so that a
+		// client disconnect (tab close / network drop) is detected immediately
+		// and cancels ctx, unblocking the select below.  Without this, the
+		// goroutine leaks until the next write attempt.
+		go func() {
+			defer cancel()
+			for {
+				if _, _, err := conn.Read(ctx); err != nil {
+					return
+				}
+			}
+		}()
+
+		for {
+			select {
+			case msg := <-incomingFromUserCh:
+				var frame map[string]interface{}
+				if msg.Sender == models.SenderSystem && msg.Message == "conversation_ended" {
+					frame = map[string]interface{}{
+						"type":            "ended",
+						"conversation_id": msg.ConversationID,
+					}
+				} else {
+					frame = map[string]interface{}{
+						"conversation_id": msg.ConversationID,
+						"sender":          msg.Sender,
+						"message":         msg.Message,
+						"timestamp":       msg.Timestamp,
+					}
+				}
+				if err := wsWrite(ctx, conn, frame); err != nil {
+					logger.Error("admin watch: write failed", zap.Error(err))
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// AdminWatchAll upgrades an admin request to a WebSocket that receives a
+// notification for every incoming user message across ALL conversations.
+// The admin panel uses this single connection to drive unread indicators in the
+// sidebar without polling.  Each frame contains user_id and conversation_id so
+// the frontend can match the right sidebar entry.
+func AdminWatchAll(c *gin.Context) {
+	logger := log.GetLogger()
+
+	type unwrapper interface{ Unwrap() http.ResponseWriter }
+	rw := http.ResponseWriter(c.Writer)
+	if u, ok := c.Writer.(unwrapper); ok {
+		rw = u.Unwrap()
+	}
+	conn, err := websocket.Accept(rw, c.Request, &websocket.AcceptOptions{
+		OriginPatterns: []string{"*"},
+	})
+	if err != nil {
+		logger.Error("admin watch-all: websocket upgrade failed", zap.Error(err))
+		return
+	}
+	c.Writer.WriteHeaderNow()
+
+	go func() {
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// incomingBroadcastCh receives a notification for every user message across all conversations.
+		incomingBroadcastCh := make(chan hubMessage, 32)
+		unsubFromBroadcast := hub.subscribe(adminBroadcastKey, incomingBroadcastCh)
+		defer unsubFromBroadcast()
+
+		logger.Info("admin watching all conversations")
+
+		// Same disconnect-detection pattern as AdminWatchConversation: drain
+		// the read side so a client close/drop cancels ctx immediately.
+		go func() {
+			defer cancel()
+			for {
+				if _, _, err := conn.Read(ctx); err != nil {
+					return
+				}
+			}
+		}()
+
+		for {
+			select {
+			case msg := <-incomingBroadcastCh:
+				frame := map[string]interface{}{
+					"user_id":         msg.UserID,
+					"conversation_id": msg.ConversationID,
+					"sender":          msg.Sender,
+				}
+				if err := wsWrite(ctx, conn, frame); err != nil {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/api/internal/pkg/pac-go-server/services/chat_hub.go
+++ b/api/internal/pkg/pac-go-server/services/chat_hub.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	log "github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/logger"
+	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
+	"go.uber.org/zap"
+)
+
+// chatHub is a simple fan-out hub.  Subscribers register a channel under an
+// arbitrary string key and receive every message published to that key.
+//
+// Two key namespaces are used:
+//   - user side:  userID            — admin → user pushes (hubMessage.Sender == "admin")
+//   - admin side: "userID:convID"   — user → admin pushes (hubMessage.Sender == "user")
+type chatHub struct {
+	mu        sync.Mutex
+	subs      map[string][]chan hubMessage
+	dropCount atomic.Int64 // total messages dropped due to full subscriber buffers
+}
+
+type hubMessage struct {
+	ConversationID int64                `json:"conversation_id"`
+	UserID         string               `json:"user_id,omitempty"`
+	Sender         models.MessageSender `json:"sender"`
+	Message        string               `json:"message"`
+	Timestamp      string               `json:"timestamp"`
+}
+
+// adminBroadcastKey is the hub key that every incoming user message is also
+// published to, so a single admin WS can receive notifications for all convs.
+const adminBroadcastKey = "admin:broadcast"
+
+var hub = &chatHub{
+	subs: make(map[string][]chan hubMessage),
+}
+
+// userToAdminKey returns the hub key under which an admin watches a specific
+// user conversation (user → admin direction: "userID:convID").
+func userToAdminKey(userID string, convID int64) string {
+	return fmt.Sprintf("%s:%d", userID, convID)
+}
+
+// subscribe registers ch under key and returns a cleanup function that removes it.
+// The returned function must be called (e.g. via defer) to avoid leaking the
+// channel in the hub after the subscriber goroutine exits.
+func (h *chatHub) subscribe(key string, ch chan hubMessage) func() {
+	h.mu.Lock()
+	h.subs[key] = append(h.subs[key], ch)
+	h.mu.Unlock()
+
+	// unsubscribe removes ch from the list under key.
+	// If the list becomes empty the key is deleted from the map entirely.
+	return func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		list := h.subs[key]
+		for i, c := range list {
+			if c == ch {
+				h.subs[key] = append(list[:i], list[i+1:]...)
+				break
+			}
+		}
+		if len(h.subs[key]) == 0 {
+			delete(h.subs, key)
+		}
+	}
+}
+
+// publish sends msg to every channel currently subscribed under key.
+// Non-blocking: if a channel's buffer is full the message is dropped for that
+// subscriber (WebSocket goroutines are assumed to drain quickly).
+//
+// Every drop increments dropCount and is logged at Warn level so that
+// "hot" conversations that are overwhelming the hub are immediately visible
+// in the server logs without any external metrics infrastructure.
+func (h *chatHub) publish(key string, msg hubMessage) {
+	h.mu.Lock()
+	list := make([]chan hubMessage, len(h.subs[key]))
+	copy(list, h.subs[key])
+	h.mu.Unlock()
+
+	for _, ch := range list {
+		select {
+		case ch <- msg:
+		default:
+			// Subscriber channel is full — message dropped.
+			// Increment the counter and emit a warning so operators can
+			// identify which conversation is generating backpressure.
+			total := h.dropCount.Add(1)
+			log.GetLogger().Warn("hub: subscriber channel full, message dropped",
+				zap.String("key", key),
+				zap.String("sender", string(msg.Sender)),
+				zap.Int64("total_drops", total),
+			)
+		}
+	}
+}

--- a/api/internal/pkg/pac-go-server/services/chat_test.go
+++ b/api/internal/pkg/pac-go-server/services/chat_test.go
@@ -1,0 +1,621 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/IBM/power-access-cloud/api/internal/pkg/pac-go-server/models"
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func chatContext(userID, username string) context.Context {
+	return getContext(testContext{userID: userID, username: username})
+}
+
+func makeSummaries(ended bool) []models.ConversationSummary {
+	return []models.ConversationSummary{
+		{
+			ConversationID: 1,
+			UserID:         "user1",
+			Username:       "alice",
+			MessageCount:   3,
+			LastMessageAt:  time.Now(),
+			Ended:          ended,
+			FirstMessage:   "hello",
+		},
+	}
+}
+
+func makeMessages() []models.ChatMessage {
+	return []models.ChatMessage{
+		{
+			ConversationID: 1,
+			UserID:         "user1",
+			Username:       "alice",
+			Message:        "hello",
+			Sender:         models.SenderUser,
+			Timestamp:      time.Now(),
+		},
+		{
+			ConversationID: 1,
+			UserID:         "user1",
+			Username:       "alice",
+			Message:        "hi there",
+			Sender:         models.SenderAdmin,
+			Timestamp:      time.Now(),
+		},
+	}
+}
+
+// ginParam attaches URL params to a Gin context, matching how the router sets them.
+func ginParam(c *gin.Context, key, value string) {
+	c.Params = append(c.Params, gin.Param{Key: key, Value: value})
+}
+
+// ── GetUserConversations ──────────────────────────────────────────────────────
+
+func TestGetUserConversations(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		userID     string
+		wantStatus int
+	}{
+		{
+			name: "returns conversations for user",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetUserConversations(gomock.Any(), "user1").
+					Return(makeSummaries(false), nil).Times(1)
+			},
+			userID:     "user1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "db error returns 500",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetUserConversations(gomock.Any(), "user1").
+					Return(nil, errors.New("db down")).Times(1)
+			},
+			userID:     "user1",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodGet, "/pac-go-server/conversations", nil)
+			c.Request = req.WithContext(chatContext(tc.userID, "alice"))
+			dbCon = mockDB
+			GetUserConversations(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// ── GetUserConversationMessages ───────────────────────────────────────────────
+
+func TestGetUserConversationMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		convID     string
+		wantStatus int
+	}{
+		{
+			name: "returns messages for valid conv id",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetChatMessages(gomock.Any(), "user1", int64(1)).
+					Return(makeMessages(), nil).Times(1)
+			},
+			convID:     "1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid conv id returns 400",
+			mockFunc:   func() {},
+			convID:     "not-a-number",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "db error returns 500",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetChatMessages(gomock.Any(), "user1", int64(2)).
+					Return(nil, errors.New("db error")).Times(1)
+			},
+			convID:     "2",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodGet, "/pac-go-server/conversations/"+tc.convID+"/messages", nil)
+			c.Request = req.WithContext(chatContext("user1", "alice"))
+			ginParam(c, "conv_id", tc.convID)
+			dbCon = mockDB
+			GetUserConversationMessages(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// ── GetAdminConversations ─────────────────────────────────────────────────────
+
+func TestGetAdminConversations(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		wantStatus int
+	}{
+		{
+			name: "returns all conversations",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetAllConversations(gomock.Any()).
+					Return(makeSummaries(false), nil).Times(1)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "db error returns 500",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetAllConversations(gomock.Any()).
+					Return(nil, errors.New("db down")).Times(1)
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodGet, "/pac-go-server/admin/conversations", nil)
+			c.Request = req.WithContext(chatContext("admin1", "adminuser"))
+			dbCon = mockDB
+			GetAdminConversations(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// ── GetAdminConversationMessages ──────────────────────────────────────────────
+
+func TestGetAdminConversationMessages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		userID     string
+		convID     string
+		wantStatus int
+	}{
+		{
+			name: "returns messages for valid user and conv",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetChatMessages(gomock.Any(), "user1", int64(1)).
+					Return(makeMessages(), nil).Times(1)
+			},
+			userID:     "user1",
+			convID:     "1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid conv id returns 400",
+			mockFunc:   func() {},
+			userID:     "user1",
+			convID:     "bad",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "db error returns 500",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					GetChatMessages(gomock.Any(), "user1", int64(1)).
+					Return(nil, errors.New("db error")).Times(1)
+			},
+			userID:     "user1",
+			convID:     "1",
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			c.Request = req.WithContext(chatContext("admin1", "adminuser"))
+			ginParam(c, "user_id", tc.userID)
+			ginParam(c, "conv_id", tc.convID)
+			dbCon = mockDB
+			GetAdminConversationMessages(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// ── AdminReply ────────────────────────────────────────────────────────────────
+
+func TestAdminReply(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		adminID    string
+		userID     string
+		convID     string
+		body       interface{}
+		wantStatus int
+	}{
+		{
+			name: "reply enqueued successfully",
+			mockFunc: func() {
+				// InsertChatMessage is called asynchronously by the worker;
+				// the handler may or may not call it directly during the test
+				// window, so we allow 0-1 calls.
+				mockDB.EXPECT().
+					InsertChatMessage(gomock.Any(), gomock.Any()).
+					Return(nil).AnyTimes()
+			},
+			adminID:    "admin1",
+			userID:     "user1",
+			convID:     "1",
+			body:       map[string]string{"message": "hello from admin"},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:       "missing message body returns 400",
+			mockFunc:   func() {},
+			adminID:    "admin1",
+			userID:     "user1",
+			convID:     "1",
+			body:       map[string]string{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid conv id returns 400",
+			mockFunc:   func() {},
+			adminID:    "admin1",
+			userID:     "user1",
+			convID:     "nan",
+			body:       map[string]string{"message": "hi"},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing admin id returns 401",
+			mockFunc:   func() {},
+			adminID:    "", // no auth
+			userID:     "user1",
+			convID:     "1",
+			body:       map[string]string{"message": "hi"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Drain the reply queue before each test so queue-full state doesn't leak.
+			for len(adminReplyQueue) > 0 {
+				<-adminReplyQueue
+			}
+
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			bodyBytes, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+			req, _ := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+			req.Header.Set("Content-Type", "application/json")
+			c.Request = req.WithContext(chatContext(tc.adminID, "adminuser"))
+			ginParam(c, "user_id", tc.userID)
+			ginParam(c, "conv_id", tc.convID)
+			dbCon = mockDB
+			AdminReply(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// TestAdminReply_QueueFull tests the synchronous-write fallback when the
+// adminReplyQueue is at capacity. It swaps in a zero-capacity channel for the
+// duration of the test and restores it afterwards.
+func TestAdminReply_QueueFull(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	// Swap the package-level queue for a zero-buffer one so the select default
+	// branch fires deterministically without racing the background worker.
+	orig := adminReplyQueue
+	adminReplyQueue = make(chan *models.ChatMessage)
+	defer func() { adminReplyQueue = orig }()
+
+	mockDB.EXPECT().
+		InsertChatMessage(gomock.Any(), gomock.Any()).
+		Return(errors.New("db write failed")).Times(1)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body, _ := json.Marshal(map[string]string{"message": "overflow"})
+	req, _ := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req.WithContext(chatContext("admin1", "adminuser"))
+	ginParam(c, "user_id", "user1")
+	ginParam(c, "conv_id", "1")
+	dbCon = mockDB
+	AdminReply(c)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ── AdminEndConversation ──────────────────────────────────────────────────────
+
+func TestAdminEndConversation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	tests := []struct {
+		name       string
+		mockFunc   func()
+		userID     string
+		convID     string
+		wantStatus int
+	}{
+		{
+			name: "ends conversation successfully",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					MarkConversationEnded(gomock.Any(), "user1", "", int64(1)).
+					Return(nil).Times(1)
+			},
+			userID:     "user1",
+			convID:     "1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			// DB failure is non-fatal — the hub is still notified and 200 returned.
+			name: "db failure is non-fatal — still returns 200",
+			mockFunc: func() {
+				mockDB.EXPECT().
+					MarkConversationEnded(gomock.Any(), "user1", "", int64(1)).
+					Return(errors.New("db error")).Times(1)
+			},
+			userID:     "user1",
+			convID:     "1",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid conv id returns 400",
+			mockFunc:   func() {},
+			userID:     "user1",
+			convID:     "bad",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mockFunc()
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			req, _ := http.NewRequest(http.MethodPost, "/", nil)
+			c.Request = req.WithContext(chatContext("admin1", "adminuser"))
+			ginParam(c, "user_id", tc.userID)
+			ginParam(c, "conv_id", tc.convID)
+			dbCon = mockDB
+			AdminEndConversation(c)
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+// ── chatHub unit tests ────────────────────────────────────────────────────────
+
+func TestChatHub_PublishToSubscribers(t *testing.T) {
+	h := &chatHub{subs: make(map[string][]chan hubMessage)}
+	ch1 := make(chan hubMessage, 1)
+	ch2 := make(chan hubMessage, 1)
+
+	unsub1 := h.subscribe("key1", ch1)
+	unsub2 := h.subscribe("key1", ch2)
+
+	msg := hubMessage{ConversationID: 1, Sender: models.SenderUser, Message: "hi"}
+	h.publish("key1", msg)
+
+	assert.Equal(t, msg, <-ch1, "ch1 should receive the published message")
+	assert.Equal(t, msg, <-ch2, "ch2 should receive the published message")
+
+	unsub1()
+	unsub2()
+}
+
+func TestChatHub_NoDeliveryAfterUnsubscribe(t *testing.T) {
+	h := &chatHub{subs: make(map[string][]chan hubMessage)}
+	ch := make(chan hubMessage, 1)
+
+	unsub := h.subscribe("key1", ch)
+	unsub() // unsubscribe immediately
+
+	h.publish("key1", hubMessage{Message: "ghost"})
+
+	select {
+	case m := <-ch:
+		t.Fatalf("expected no message after unsub, got %v", m)
+	default:
+		// correct — nothing delivered
+	}
+}
+
+func TestChatHub_KeyDeletedWhenEmpty(t *testing.T) {
+	h := &chatHub{subs: make(map[string][]chan hubMessage)}
+	ch := make(chan hubMessage, 1)
+
+	unsub := h.subscribe("key1", ch)
+	h.mu.Lock()
+	_, exists := h.subs["key1"]
+	h.mu.Unlock()
+	assert.True(t, exists, "key should exist after subscribe")
+
+	unsub()
+	h.mu.Lock()
+	_, exists = h.subs["key1"]
+	h.mu.Unlock()
+	assert.False(t, exists, "key should be deleted after last unsub")
+}
+
+func TestChatHub_DropsMessageWhenBufferFull(t *testing.T) {
+	h := &chatHub{subs: make(map[string][]chan hubMessage)}
+	// Buffer size 1 — fill it so the next publish triggers the drop path.
+	ch := make(chan hubMessage, 1)
+	ch <- hubMessage{Message: "blocker"}
+	unsub := h.subscribe("key1", ch)
+	defer unsub()
+
+	h.publish("key1", hubMessage{Message: "dropped"})
+
+	assert.Equal(t, int64(1), h.dropCount.Load(), "drop counter should be 1")
+	// Original message is still in the buffer, not the dropped one.
+	assert.Equal(t, "blocker", (<-ch).Message)
+}
+
+func TestChatHub_MultipleKeys_Isolated(t *testing.T) {
+	h := &chatHub{subs: make(map[string][]chan hubMessage)}
+	chA := make(chan hubMessage, 1)
+	chB := make(chan hubMessage, 1)
+
+	unsubA := h.subscribe("keyA", chA)
+	unsubB := h.subscribe("keyB", chB)
+	defer unsubA()
+	defer unsubB()
+
+	h.publish("keyA", hubMessage{Message: "for A"})
+
+	select {
+	case m := <-chA:
+		assert.Equal(t, "for A", m.Message)
+	default:
+		t.Fatal("chA should have received message")
+	}
+	select {
+	case m := <-chB:
+		t.Fatalf("chB should not have received message from keyA, got %v", m)
+	default:
+		// correct
+	}
+}
+
+func TestUserToAdminKey(t *testing.T) {
+	assert.Equal(t, "abc:42", userToAdminKey("abc", 42))
+	assert.Equal(t, "xyz:1", userToAdminKey("xyz", 1))
+}
+
+// ── StartAdminReplyWorker ─────────────────────────────────────────────────────
+
+func TestStartAdminReplyWorker_PersistsMessages(t *testing.T) {
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	dbCon = mockDB
+	mockDB.EXPECT().
+		InsertChatMessage(gomock.Any(), gomock.Any()).
+		Return(nil).Times(2)
+
+	// Drain any leftover items from earlier tests.
+	for len(adminReplyQueue) > 0 {
+		<-adminReplyQueue
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Enqueue two messages before starting the worker.
+	adminReplyQueue <- &models.ChatMessage{UserID: "u1", ConversationID: 1, Message: "m1"}
+	adminReplyQueue <- &models.ChatMessage{UserID: "u1", ConversationID: 1, Message: "m2"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		StartAdminReplyWorker(ctx)
+	}()
+
+	// Give the worker time to drain the two messages, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+}
+
+func TestStartAdminReplyWorker_DrainOnShutdown(t *testing.T) {
+	_, mockDB, _, tearDown := setUp(t)
+	defer tearDown()
+
+	dbCon = mockDB
+	// One message already in the queue when shutdown fires — must still be persisted.
+	mockDB.EXPECT().
+		InsertChatMessage(gomock.Any(), gomock.Any()).
+		Return(nil).Times(1)
+
+	for len(adminReplyQueue) > 0 {
+		<-adminReplyQueue
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so the worker enters shutdown drain
+
+	adminReplyQueue <- &models.ChatMessage{UserID: "u1", ConversationID: 1, Message: "drain me"}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		StartAdminReplyWorker(ctx)
+	}()
+
+	select {
+	case <-done:
+		// worker exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit within timeout")
+	}
+}

--- a/api/internal/pkg/pac-go-server/services/notification.go
+++ b/api/internal/pkg/pac-go-server/services/notification.go
@@ -1,10 +1,8 @@
 package services
 
 import (
+	"context"
 	"fmt"
-
-	// "net/http"
-
 	"time"
 
 	"go.uber.org/zap"
@@ -123,15 +121,20 @@ func isNotificationSentRecently(serviceName string, notificationType models.Even
 	return false
 }
 
-// ExpiryNotification raises notification for about-to-expire services
-func ExpiryNotification() {
-	go func() {
-		every := time.Duration(everyDay) * time.Hour
-		ticker := time.NewTicker(every)
-		defer ticker.Stop()
+// ExpiryNotification raises notification for about-to-expire services.
+// It blocks until ctx is cancelled, so callers must run it in a goroutine.
+func ExpiryNotification(ctx context.Context) {
+	every := time.Duration(everyDay) * time.Hour
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
 
-		for range ticker.C {
+	for {
+		select {
+		case <-ticker.C:
 			raiseNotification()
+		case <-ctx.Done():
+			log.GetLogger().Info("ExpiryNotification: context cancelled, exiting")
+			return
 		}
-	}()
+	}
 }

--- a/web/conf/conf.d/pac.conf.template
+++ b/web/conf/conf.d/pac.conf.template
@@ -17,6 +17,15 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
         proxy_set_header   Host              $http_host;
         proxy_set_header   X-Real-IP         $remote_addr;
+        # Required for WebSocket proxying — without these nginx strips the
+        # Upgrade header and the Go backend responds with 426.
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade    $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        # nginx default proxy_read_timeout is 60 s. For WebSocket connections
+        # that means any 60 s of silence drops the connection. Set to 1 h so
+        # idle chat sessions are not killed by nginx between messages.
+        proxy_read_timeout 3600s;
   }
   error_page   500 502 503 504  /50x.html;
   location = /50x.html {

--- a/web/src/components/App.jsx
+++ b/web/src/components/App.jsx
@@ -22,6 +22,8 @@ import { Theme } from "@carbon/react";
 import Feedbacks from "./Feedbacks";
 import MaintenanceNotification from "./MaintenanceNotification";
 import MaintenanceManager from "./MaintenanceManager";
+import ChatSupport from "./ChatSupport";
+import ChatAdmin from "./ChatAdmin";
 
 const RouterClass = React.memo(({ isAdmin }) => {
     return (
@@ -45,6 +47,9 @@ const RouterClass = React.memo(({ isAdmin }) => {
         )}
         {!isAdmin && (
           <Route path="/catalogs" element={<TnCRoute Component={Catalogs} />} />
+        )}
+        {!isAdmin && (
+          <Route path="/chat-support" element={<TnCRoute Component={ChatSupport} />} />
         )}
 
         {isAdmin && (
@@ -92,6 +97,12 @@ const RouterClass = React.memo(({ isAdmin }) => {
             element={<TnCRoute Component={MaintenanceManager} />}
           />
         )}
+        {isAdmin && (
+          <Route
+            path="/chat-admin"
+            element={<TnCRoute Component={ChatAdmin} />}
+          />
+        )}
       </Routes>
     );
 });
@@ -120,6 +131,7 @@ const App = () => {
       "/keys",
       "/feedbacks",
       "/maintenance",
+      "/chat-admin",
     ].includes(window.location.pathname)
   ) {
     window.location.href = "/login";

--- a/web/src/components/ChatAdmin.jsx
+++ b/web/src/components/ChatAdmin.jsx
@@ -1,0 +1,522 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { Send, Renew } from "@carbon/icons-react";
+import {
+  Button,
+  DataTableSkeleton,
+  InlineNotification,
+  TextArea,
+} from "@carbon/react";
+import "../styles/chat-support.scss";
+import axios from "axios";
+import UserService from "../services/UserService";
+
+const api = axios.create();
+api.interceptors.request.use((config) => {
+  const cb = () => {
+    config.headers.Authorization = `Bearer ${UserService.getToken()}`;
+    return Promise.resolve(config);
+  };
+  return UserService.updateToken(cb);
+});
+
+// Returns "username-conv-N" if username is available, else falls back to userID.
+const convLabel = (username, userID, convID) =>
+  `${username || userID}-conv-${convID}`;
+
+// Unique key for a (userID, convID) pair — used for unread tracking.
+const convKey = (userID, convID) => `${userID}__${convID}`;
+
+const ChatAdmin = () => {
+  const [conversations, setConversations] = useState([]);
+  const [selected, setSelected] = useState(null); // { userID, convID }
+  const [messages, setMessages] = useState([]);
+  const [replyText, setReplyText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [msgLoading, setMsgLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [convEnded, setConvEnded] = useState(false); // true after conversation ended
+  // unreadCounts: { [convKey]: number } — count of unread user messages per conv.
+  const [unreadCounts, setUnreadCounts] = useState({});
+  // newConvAlert: userID of a user who started a new conversation while the admin
+  // is still viewing their previous (now-ended) conversation.  Shown as an inline
+  // banner so the admin knows to click the new sidebar entry.  null = no alert.
+  const [newConvAlert, setNewConvAlert] = useState(null);
+
+  // Ref to the live-watch WebSocket for the currently selected conversation.
+  const watchWsRef = useRef(null);
+  const messagesEndRef = useRef(null);
+  // Ref copy of selected so WS onmessage can read it without a stale closure.
+  const selectedRef = useRef(null);
+  // Ref copy of conversations so the watch-all WS handler can check for new
+  // conversations without a stale closure.
+  const conversationsRef = useRef([]);
+
+  // Auto-scroll to the latest message whenever the list changes.
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // Keep selectedRef in sync with selected state.
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
+  const loadConversations = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await api.get("/pac-go-server/admin/conversations");
+      const list = res.data.conversations ?? [];
+      conversationsRef.current = list;
+      setConversations(list);
+    } catch (err) {
+      setError("Failed to load conversations: " + (err.response?.data?.error ?? err.message));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConversations();
+  }, [loadConversations]);
+
+  // Close any existing watch WebSocket cleanly.
+  const closeWatchWs = () => {
+    const ws = watchWsRef.current;
+    if (ws) {
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      ws.close(1000, "conversation changed");
+      watchWsRef.current = null;
+    }
+  };
+
+  // Open a watch WebSocket for (userID, convID) and append incoming messages.
+  // Reconnects automatically with a fresh token on unexpected close so that
+  // token expiry doesn't silently stop live updates in the open chat panel.
+  const openWatchWs = (userID, convID) => {
+    // If a healthy socket for this exact conversation is already open, reuse it —
+    // this covers the ended → same active conv navigation case.
+    const existing = watchWsRef.current;
+    if (existing && existing._convID === convID && existing.readyState === WebSocket.OPEN) {
+      return;
+    }
+    closeWatchWs();
+
+    const connect = () => {
+      // closeWatchWs() may have been called between the reconnect timer firing
+      // and this callback running — bail out if a different conv is now selected.
+      if (watchWsRef.current !== null && watchWsRef.current._convID !== convID) return;
+
+      UserService.updateToken(() => {
+        // Guard again: the conv may have changed while the token refresh was async.
+        if (watchWsRef.current !== null && watchWsRef.current._convID !== convID) return;
+
+        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const token = UserService.getToken();
+        const url = `${protocol}//${window.location.host}/pac-go-server/admin/conversations/${userID}/${convID}/ws?token=${encodeURIComponent(token)}`;
+
+        const ws = new WebSocket(url);
+        ws._convID = convID; // tag so reconnect guards above can identify it
+        watchWsRef.current = ws;
+
+        ws.onmessage = (event) => {
+          if (watchWsRef.current !== ws) return;
+          try {
+            const data = JSON.parse(event.data);
+
+            // Conversation ended signal from the hub.
+            if (data.type === "ended") {
+              setConvEnded(true);
+              return;
+            }
+
+            if (data.sender && data.message) {
+              setMessages((prev) => [
+                ...prev,
+                {
+                  id: data.id ?? Date.now(),
+                  sender: data.sender,
+                  message: data.message,
+                  timestamp: data.timestamp,
+                },
+              ]);
+            }
+          } catch (e) {
+            console.error("admin watch WS parse error", e);
+          }
+        };
+
+        ws.onerror = () => console.error("admin watch WS error");
+
+        ws.onclose = (ev) => {
+          if (watchWsRef.current !== ws) return;
+          watchWsRef.current = null;
+          // 1000 = intentional close (conversation changed / unmount) — do not reconnect.
+          if (ev.code !== 1000) {
+            setTimeout(connect, 3000);
+          }
+        };
+      });
+    };
+
+    connect();
+  };
+
+  // Close the watch WS when the component unmounts.
+  useEffect(() => () => closeWatchWs(), []);
+
+  // Single persistent WebSocket that subscribes to ALL user messages across
+  // all conversations.  When a message arrives for a conv that isn't currently
+  // selected, we mark it unread in the sidebar.
+  // Reconnects automatically on close/error with a fresh token each time so
+  // that token expiry never silently kills the live-update stream.
+  useEffect(() => {
+    let ws = null;
+    let reconnectTimer = null;
+    let unmounted = false;
+
+    const onMessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (!data.user_id || !data.conversation_id) return;
+
+        // If this (user_id, conv_id) pair is not yet in the sidebar list,
+        // reload conversations so the new entry appears immediately.
+        // This also covers the case where a user started a brand-new conversation
+        // after admin ended the previous one — the new convID won't be in the list yet.
+        const known = conversationsRef.current.some(
+          (c) => c.user_id === data.user_id && c.conversation_id === data.conversation_id
+        );
+        if (!known) {
+          loadConversations();
+        }
+
+        const sel = selectedRef.current;
+        const isSelected =
+          sel?.userID === data.user_id && sel?.convID === data.conversation_id;
+
+        // If the admin is currently watching this user's conversation but the
+        // incoming message belongs to a NEWER conv for the same user, the watch
+        // WS is stale. Mark the new conv unread so the admin notices it in the
+        // sidebar — they must click it to switch the watch to the new conv.
+        const isSameUserDifferentConv =
+          sel?.userID === data.user_id && sel?.convID !== data.conversation_id;
+
+        if (!isSelected) {
+          const key = convKey(data.user_id, data.conversation_id);
+          setUnreadCounts((prev) => ({ ...prev, [key]: (prev[key] ?? 0) + 1 }));
+        }
+
+        if (isSameUserDifferentConv) {
+          const existingConv = conversationsRef.current.find((c) => c.user_id === data.user_id);
+          setNewConvAlert(existingConv?.username || data.user_id);
+        }
+      } catch (e) {
+        console.error("admin watch-all WS parse error", e);
+      }
+    };
+
+    const connect = () => {
+      if (unmounted) return;
+      // If a socket is already connecting or open, don't open another one.
+      if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+        return;
+      }
+      // Always get a fresh token at connect time — handles expiry between reconnects.
+      UserService.updateToken(() => {
+        if (unmounted) return;
+        // Guard again after the async token refresh — state may have changed.
+        if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) {
+          return;
+        }
+        const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+        const token = UserService.getToken();
+        const url = `${protocol}//${window.location.host}/pac-go-server/admin/watch?token=${encodeURIComponent(token)}`;
+        ws = new WebSocket(url);
+
+        ws.onmessage = onMessage;
+        ws.onerror = () => console.error("admin watch-all WS error");
+        ws.onclose = (ev) => {
+          if (unmounted) return;
+          // 1000 = intentional close from cleanup — do not reconnect.
+          if (ev.code !== 1000) {
+            reconnectTimer = setTimeout(connect, 3000);
+          }
+        };
+      });
+    };
+
+    connect();
+
+    return () => {
+      unmounted = true;
+      clearTimeout(reconnectTimer);
+      if (ws) {
+        ws.onclose = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.close(1000, "unmount");
+      }
+    };
+  }, [loadConversations]);
+
+  const selectConversation = async (userID, convID, alreadyEnded = false, username = "") => {
+    const key = convKey(userID, convID);
+    setSelected({ userID, convID, username });
+    setMessages([]);
+    setReplyText("");
+    setSuccess("");
+    setConvEnded(alreadyEnded); // restore persisted ended state immediately
+    // Dismiss the new-conv alert when the admin navigates to any conversation.
+    setNewConvAlert(null);
+    // Clear unread count for this conv.
+    setUnreadCounts((prev) => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setMsgLoading(true);
+    try {
+      const res = await api.get(`/pac-go-server/admin/conversations/${userID}/${convID}/messages`);
+      const msgs = res.data.messages ?? [];
+      setMessages(msgs);
+    } catch (err) {
+      setError("Failed to load messages: " + (err.response?.data?.error ?? err.message));
+    } finally {
+      setMsgLoading(false);
+    }
+    // Only open a live-watch WebSocket for active conversations — ended
+    // conversations are immutable so there is nothing new to receive.
+    // When navigating TO an ended conv, deliberately keep any existing watch
+    // socket alive (don't closeWatchWs) so that coming back to the active conv
+    // reuses the same socket instead of creating a new one.
+    if (!alreadyEnded) {
+      openWatchWs(userID, convID);
+    }
+    // else: ended conv — leave watchWsRef untouched, openWatchWs's OPEN guard
+    // will skip reopening when the admin navigates back to the active conv.
+  };
+
+  const sendReply = async () => {
+    if (!replyText.trim() || !selected || convEnded) return;
+    setSuccess("");
+    setError("");
+    const text = replyText;
+    setReplyText("");
+    try {
+      await api.post(
+        `/pac-go-server/admin/conversations/${selected.userID}/${selected.convID}/reply`,
+        { message: text }
+      );
+    } catch (err) {
+      setReplyText(text); // restore on failure
+      setError("Failed to send reply: " + (err.response?.data?.error ?? err.message));
+    }
+  };
+
+  // onKeyDown for the reply textarea: Enter submits, Shift+Enter adds a newline.
+  const onReplyKeyDown = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendReply();
+    }
+  };
+
+  const endConversation = async () => {
+    if (!selected || convEnded) return;
+    setError("");
+    try {
+      await api.post(
+        `/pac-go-server/admin/conversations/${selected.userID}/${selected.convID}/end`
+      );
+      setConvEnded(true);
+      setSuccess("Conversation ended.");
+      // Refresh the conversation list so the new conv appears.
+      loadConversations();
+    } catch (err) {
+      setError("Failed to end conversation: " + (err.response?.data?.error ?? err.message));
+    }
+  };
+
+  const formatTime = (ts) =>
+    new Date(ts).toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: true,
+    });
+
+  return (
+    <div className="chat-support-container chat-support-container--admin">
+      {/* Left panel — conversation list */}
+      <div className="conversations-panel">
+        <div className="conversations-header">
+          <h3>Conversations</h3>
+          <Button
+            kind="ghost"
+            size="sm"
+            renderIcon={Renew}
+            iconDescription="Refresh"
+            onClick={loadConversations}
+            hasIconOnly
+          />
+        </div>
+
+        {loading && <DataTableSkeleton columnCount={1} rowCount={4} />}
+
+        {!loading && conversations.length === 0 && (
+          <p className="empty-state-text">No conversations yet</p>
+        )}
+
+        <div className="conversations-list">
+          {conversations.map((conv) => {
+            const isActive =
+              selected?.userID === conv.user_id &&
+              selected?.convID === conv.conversation_id;
+            const unreadCount = unreadCounts[convKey(conv.user_id, conv.conversation_id)] ?? 0;
+            return (
+              <div
+                key={`${conv.user_id}-${conv.conversation_id}`}
+                className={`conversation-item${isActive ? " active" : ""}${conv.ended ? " conversation-item--ended" : ""}`}
+                onClick={() => selectConversation(conv.user_id, conv.conversation_id, conv.ended, conv.username)}
+              >
+                <div className="conversation-avatar">
+                  <div className={`avatar-circle${conv.ended ? " avatar-circle--ended" : ""}`}>
+                    {(conv.username || conv.user_id)?.[0]?.toUpperCase() ?? "U"}
+                  </div>
+                </div>
+                <div className="conversation-details">
+                  <div className="conversation-id">
+                    {convLabel(conv.username, conv.user_id, conv.conversation_id)}
+                  </div>
+                  <div className="conversation-status">
+                    {conv.ended
+                      ? <span className="conv-ended-badge">Ended</span>
+                      : <span className="status-connected">Active</span>}
+                  </div>
+                  <div className="conversation-unread">
+                    {unreadCount > 0
+                      ? <><span className="unread-dot" />{unreadCount} unread</>
+                      : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Right panel — message thread + reply */}
+      <div className="chat-panel">
+        {error && (
+          <InlineNotification
+            kind="error"
+            title="Error"
+            subtitle={error}
+            onCloseButtonClick={() => setError("")}
+          />
+        )}
+        {success && (
+          <InlineNotification
+            kind="success"
+            title="Success"
+            subtitle={success}
+            onCloseButtonClick={() => setSuccess("")}
+          />
+        )}
+        {newConvAlert && (
+          <InlineNotification
+            kind="warning"
+            title="New conversation"
+            subtitle={`${newConvAlert} started a new conversation — select it in the sidebar.`}
+            onCloseButtonClick={() => setNewConvAlert(null)}
+          />
+        )}
+
+        {!selected ? (
+          <div className="empty-state">
+            <p>Select a conversation on the left to view messages</p>
+          </div>
+        ) : (
+          <>
+            <div className="chat-header">
+              <h2>{convLabel(selected.username, selected.userID, selected.convID)}</h2>
+              <div className="chat-status">
+                <span className="status-label" style={{ fontWeight: 600, marginRight: 8 }}>
+                  User: {selected.username || selected.userID}
+                </span>
+                {!convEnded && (
+                  <button
+                    className="end-conv-button"
+                    onClick={endConversation}
+                    title="End this conversation"
+                  >
+                    End Conversation
+                  </button>
+                )}
+                {convEnded && (
+                  <span className="conv-ended-badge">Ended</span>
+                )}
+              </div>
+            </div>
+
+            <div className="chat-messages">
+              {msgLoading && <DataTableSkeleton columnCount={1} rowCount={3} />}
+              {!msgLoading && messages.length === 0 && (
+                <div className="empty-state">
+                  <p>No messages in this conversation</p>
+                </div>
+              )}
+              {!msgLoading &&
+                messages.map((msg, idx) => (
+                  <div
+                    key={msg.id ?? idx}
+                    className={`message ${msg.sender === "user" ? "message-user" : "message-admin"}`}
+                  >
+                    <div className="message-content">
+                      <div className="message-header">
+                        <span className="message-sender">
+                          [{msg.sender === "user" ? "User" : "Admin"},{" "}
+                          {formatTime(msg.timestamp)}]:
+                        </span>
+                      </div>
+                      <div className="message-text">{msg.message}</div>
+                    </div>
+                  </div>
+                ))}
+              <div ref={messagesEndRef} />
+            </div>
+
+            <div className="chat-input-container">
+              <div className="chat-input-wrapper admin-reply-wrapper">
+                <TextArea
+                  className="chat-textarea"
+                  placeholder={convEnded ? "Conversation ended" : "Type your reply… (Enter to send, Shift+Enter for new line)"}
+                  value={replyText}
+                  onChange={(e) => setReplyText(e.target.value)}
+                  onKeyDown={onReplyKeyDown}
+                  rows={2}
+                  labelText=""
+                  disabled={convEnded}
+                />
+                <button
+                  className="send-button"
+                  onClick={sendReply}
+                  disabled={!replyText.trim() || convEnded}
+                >
+                  <Send size={20} />
+                  <span>Reply</span>
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChatAdmin;

--- a/web/src/components/ChatSupport.jsx
+++ b/web/src/components/ChatSupport.jsx
@@ -1,0 +1,529 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { Send, Add } from "@carbon/icons-react";
+import UserService from "../services/UserService";
+import axios from "axios";
+import "../styles/chat-support.scss";
+
+// Axios instance that attaches the Bearer token to every request.
+const _axios = axios.create();
+_axios.interceptors.request.use((config) => {
+  if (UserService.isLoggedIn()) {
+    const cb = () => {
+      config.headers.Authorization = `Bearer ${UserService.getToken()}`;
+      return Promise.resolve(config);
+    };
+    return UserService.updateToken(cb);
+  }
+});
+
+const ChatSupport = () => {
+  const [messages, setMessages] = useState([]);
+  const [inputMessage, setInputMessage] = useState("");
+  const [conversationId, setConversationId] = useState(null);   // numeric ID from server
+  const [connectionStatus, setConnectionStatus] = useState("connecting");
+  const [wsOpen, setWsOpen] = useState(false);
+  const [ended, setEnded] = useState(false);  // true after user ends conv, before new one starts
+  // pastConversations: list of {id, messageCount, messages|null} — messages loaded lazily on click
+  const [pastConversations, setPastConversations] = useState([]);
+  // selectedPastId: which past conv is selected in the sidebar (null = current active conv)
+  const [selectedPastId, setSelectedPastId] = useState(null);
+  // unreadCounts: { [convId]: number } — admin replies received while that conv is not in view
+  const [unreadCounts, setUnreadCounts] = useState({});
+  const wsRef = useRef(null);
+  const reconnectTimer = useRef(null);
+  const messagesEndRef = useRef(null);
+  // Flipped to false on intentional unmount so the onclose handler
+  // does not schedule a reconnect after the component is gone.
+  const shouldReconnect = useRef(true);
+  // Set to true by startNewConversation so the next hello frame does not
+  // restore a persisted ended state for the same conv ID.
+  const startingNewConv = useRef(false);
+
+  const username = UserService.getUsername() ?? "user";
+
+  // Derived display label: "username-conv-N"
+  const convLabel = conversationId != null ? `${username}-conv-${conversationId}` : null;
+
+  // On mount: fetch the user's past conversations from the server so the sidebar
+  // is populated even after a page navigation.
+  useEffect(() => {
+    _axios.get("/pac-go-server/conversations")
+      .then((res) => {
+        const convs = res.data.conversations ?? [];
+        const mapped = convs.map((c) => ({
+          id: c.conversation_id,
+          messageCount: c.message_count,
+          firstMessage: c.first_message || `Conversation ${c.conversation_id}`,
+          ended: c.ended,
+          messages: null,
+        }));
+        setPastConversations(mapped);
+      })
+      .catch((err) => console.error("failed to load conversations", err));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    shouldReconnect.current = true;
+
+    const buildWsUrl = () => {
+      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+      const token = UserService.getToken();
+      return `${protocol}//${window.location.host}/pac-go-server/chat?token=${encodeURIComponent(token)}`;
+    };
+
+    const connect = () => {
+      if (!shouldReconnect.current) return;
+      // Refresh the token before every connect attempt. Keycloak on staging
+      // issues 5-minute access tokens — the token baked into the WS URL expires
+      // mid-session and the server closes the connection. updateToken() silently
+      // fetches a new token via the refresh token so the next WS URL is fresh.
+      UserService.updateToken(() => {
+        if (!shouldReconnect.current) return;
+
+        // Close any existing socket before opening a new one.
+        // Detach onclose first so the close doesn't schedule a reconnect.
+        if (wsRef.current) {
+          wsRef.current.onclose = null;
+          wsRef.current.onerror = null;
+          wsRef.current.close(1000, "reconnecting");
+        }
+
+        const ws = new WebSocket(buildWsUrl());
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          if (wsRef.current !== ws) return;
+          setConnectionStatus("connected");
+          setWsOpen(true);
+        };
+
+        ws.onmessage = (event) => {
+          if (wsRef.current !== ws) return;
+          try {
+            const data = JSON.parse(event.data);
+
+            // Hello frame: sent immediately on connect with conversation_id + history + ended.
+            if (data.type === "hello") {
+              const isStartingNew = startingNewConv.current;
+              startingNewConv.current = false; // consume the flag
+              setConversationId(data.conversation_id);
+              // The server is the authoritative source for ended state.
+              // Only override with false when the user explicitly started a new conv,
+              // to prevent a stale DB state from blocking the fresh input.
+              setEnded(isStartingNew ? false : !!data.ended);
+              const history = data.history ?? [];
+              setMessages(
+                history.map((m) => ({
+                  id: m.id,
+                  sender: m.sender === "user" ? "You" : m.sender === "system" ? "System" : "Admin",
+                  content: m.message,
+                  timestamp: new Date(m.timestamp),
+                }))
+              );
+              return;
+            }
+
+            // Conversation ended (by user or by admin remote-end).
+            // Keep the current messages visible in the left panel as a past conv.
+            // Do NOT clear messages or assign a new conv ID yet — wait for the user
+            // to explicitly click "Start new conversation".
+            if (data.type === "ended") {
+              setEnded(true);
+              // Merge the in-memory messages into the pastConversations entry that was
+              // pre-populated by the on-mount fetch (or add it if not present yet).
+              setConversationId((currentId) => {
+                setMessages((currentMessages) => {
+                  setPastConversations((prev) => {
+                    const exists = prev.some((c) => c.id === currentId);
+                    const firstMessage = currentMessages.find((m) => m.sender === "You")?.content
+                      || `Conversation ${currentId}`;
+                    if (exists) {
+                      return prev.map((c) =>
+                        c.id === currentId ? { ...c, ended: true, firstMessage, messages: currentMessages } : c
+                      );
+                    }
+                    return [...prev, { id: currentId, ended: true, firstMessage, messageCount: currentMessages.length, messages: currentMessages }];
+                  });
+                  return currentMessages;
+                });
+                return currentId;
+              });
+              return;
+            }
+
+            // Echo after send: update conversationId in case it wasn't set yet.
+            if (data.conversation_id) {
+              setConversationId((prev) => prev ?? data.conversation_id);
+            }
+
+            // Admin or system reply arriving mid-conversation.
+            if (data.sender === "admin" || data.sender === "system") {
+              setMessages((prev) => [
+                ...prev,
+                {
+                  id: data.id ?? Date.now(),
+                  sender: data.sender === "system" ? "System" : "Admin",
+                  content: data.message,
+                  timestamp: data.timestamp ? new Date(data.timestamp) : new Date(),
+                },
+              ]);
+              // If the user is currently viewing a past conv (not the active one),
+              // increment the unread counter for the active conv.
+              setSelectedPastId((currentPastId) => {
+                if (currentPastId !== null) {
+                  setConversationId((cid) => {
+                    if (cid != null) {
+                      setUnreadCounts((prev) => ({ ...prev, [cid]: (prev[cid] ?? 0) + 1 }));
+                    }
+                    return cid;
+                  });
+                }
+                return currentPastId;
+              });
+            }
+
+            if (data.error) {
+              console.error("Server error:", data.error);
+            }
+          } catch (err) {
+            console.error("Error parsing WS message", err);
+          }
+        };
+
+        ws.onerror = () => {
+          if (wsRef.current !== ws) return;
+          setConnectionStatus("error");
+        };
+
+        ws.onclose = (event) => {
+          if (wsRef.current !== ws) return;
+          wsRef.current = null;
+          setWsOpen(false);
+          if (!shouldReconnect.current) {
+            setConnectionStatus("error");
+            return;
+          }
+          // 1008 = policy violation, 4001 = explicit auth rejection from server.
+          // These are hard failures — retrying with the same credentials won't help.
+          // 1006 (abnormal close) is NOT treated as a hard failure: it fires on
+          // token expiry mid-session. updateToken() inside connect() will refresh
+          // the token transparently before the next WS upgrade attempt.
+          const hardAuthFailure = event.code === 1008 || event.code === 4001;
+          if (hardAuthFailure) {
+            setConnectionStatus("error");
+            return;
+          }
+          setConnectionStatus("disconnected");
+          reconnectTimer.current = setTimeout(connect, 3000);
+        };
+      });
+    };
+
+    connect();
+
+    return () => {
+      shouldReconnect.current = false;
+      clearTimeout(reconnectTimer.current);
+      const ws = wsRef.current;
+      wsRef.current = null;
+      if (ws) {
+        ws.onopen = null;
+        ws.onclose = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.close(1000, "unmount");
+      }
+      setWsOpen(false);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const formatTime = (date) =>
+    date.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: true,
+    });
+
+  // Splits a string on http(s):// URLs and renders each URL as a clickable <a>.
+  const renderContent = (text) => {
+    const parts = text.split(/(https?:\/\/[^\s]+)/g);
+    return parts.map((part, i) =>
+      /^https?:\/\//.test(part)
+        ? <a key={i} href={part} target="_blank" rel="noopener noreferrer">{part}</a>
+        : part
+    );
+  };
+
+  const statusLabel = {
+    connected: "Active",
+    connecting: "Connecting…",
+    disconnected: "Reconnecting…",
+    error: "Connection error — please refresh",
+  };
+
+  // startNewConversation: clear the view and allow the user to type.
+  // The actual new conversation ID is assigned lazily by the server on the
+  // first message — we just need to un-block the input here.
+  const startNewConversation = useCallback(() => {
+    startingNewConv.current = true; // tell the next hello frame to ignore persisted ended state
+    setEnded(false);
+    setMessages([]);
+    setSelectedPastId(null);
+    setConversationId(null); // clear so the header shows "Initializing…" until server echoes new ID
+  }, []);
+
+  const sendMessage = useCallback(() => {
+    const ws = wsRef.current;
+    if (!inputMessage.trim() || !ws || ws.readyState !== WebSocket.OPEN || ended) return;
+
+    ws.send(JSON.stringify({ message: inputMessage }));
+
+    setMessages((prev) => [
+      ...prev,
+      { id: Date.now(), sender: "You", content: inputMessage, timestamp: new Date() },
+    ]);
+    setInputMessage("");
+  }, [inputMessage, ended]);
+
+  const endConversation = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || ended) return;
+    ws.send(JSON.stringify({ action: "end_conversation" }));
+    // ended state is set when the server echoes back the "ended" frame,
+    // not optimistically here, so the frame is the single source of truth.
+  }, [ended]);
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  // selectPastConv: click handler that sets the selection and lazily fetches messages if not yet loaded.
+  const selectPastConv = useCallback((convId) => {
+    setSelectedPastId(convId);
+    if (convId == null) return;
+    setPastConversations((prev) => {
+      const entry = prev.find((c) => c.id === convId);
+      if (!entry || entry.messages !== null) return prev; // already loaded
+      // Kick off the fetch; update the entry when it resolves.
+      _axios.get(`/pac-go-server/conversations/${convId}/messages`)
+        .then((res) => {
+          const msgs = (res.data.messages ?? []).map((m) => ({
+            id: m.id,
+            sender: m.sender === "user" ? "You" : "Admin",
+            content: m.message,
+            timestamp: new Date(m.timestamp),
+          }));
+          setPastConversations((p) =>
+            p.map((c) => c.id === convId ? { ...c, messages: msgs } : c)
+          );
+        })
+        .catch((err) => console.error("failed to load messages for conv", convId, err));
+      return prev; // no state change yet — fetch is async
+    });
+  }, []);
+
+  // selectedPastConv: the past conversation object currently selected in the sidebar (or null)
+  const selectedPastConv = selectedPastId != null
+    ? pastConversations.find((c) => c.id === selectedPastId) ?? null
+    : null;
+
+  // displayedMessages / displayedConvId: what the right panel shows
+  const displayedMessages = selectedPastConv ? (selectedPastConv.messages ?? []) : messages;
+  const displayedConvId = selectedPastConv ? selectedPastConv.id : conversationId;
+  const displayedEnded = selectedPastConv ? true : ended;
+  const displayedLoading = selectedPastConv && selectedPastConv.messages === null;
+
+  return (
+    <div className="chat-support-container">
+      {/* Left panel */}
+      <div className="conversations-panel">
+        <div className="conversations-header">
+          <h3>Conversations</h3>
+        </div>
+        <div className="conversations-list">
+          {/* Current active/new conversation — always on top */}
+          {!ended && (
+            <div
+              className={`conversation-item${!selectedPastId ? " active" : ""}`}
+              onClick={() => {
+                setSelectedPastId(null);
+                // Clear unread for the active conv when clicking back to it.
+                if (conversationId != null) {
+                  setUnreadCounts((prev) => {
+                    if (!prev[conversationId]) return prev;
+                    const next = { ...prev };
+                    delete next[conversationId];
+                    return next;
+                  });
+                }
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              <div className="conversation-avatar">
+                <div className="avatar-circle">{username[0]?.toUpperCase() ?? "U"}</div>
+              </div>
+              <div className="conversation-details">
+                <div className="conversation-id" title={messages.find((m) => m.sender === "You")?.content}>
+                  {(() => {
+                    const first = messages.find((m) => m.sender === "You")?.content;
+                    if (!first) return "New conversation";
+                    return first.length > 28 ? first.slice(0, 28) + "…" : first;
+                  })()}
+                </div>
+                <div className={`conversation-status status-${connectionStatus}`}>
+                  {statusLabel[connectionStatus]}
+                </div>
+                <div className="conversation-unread">
+                  {conversationId != null && unreadCounts[conversationId] > 0
+                    ? <><span className="unread-dot" />{unreadCounts[conversationId]} unread</>
+                    : (messages.length === 0 ? "Start chatting" : null)}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Past ended conversations — newest first (server returns DESC order).
+              Exclude: (a) the current active conv by ID, and (b) any non-ended conv
+              to avoid flashing an "active" conv in the past list before the hello
+              frame arrives and sets conversationId. */}
+          {pastConversations
+            .filter((conv) => conv.id !== conversationId && conv.ended)
+            .map((conv) => (
+              <div
+                key={conv.id}
+                className={`conversation-item conversation-item--ended${selectedPastId === conv.id ? " active" : ""}`}
+                onClick={() => selectPastConv(conv.id)}
+                style={{ cursor: "pointer" }}
+              >
+                <div className="conversation-avatar">
+                  <div className="avatar-circle avatar-circle--ended">{username[0]?.toUpperCase() ?? "U"}</div>
+                </div>
+                <div className="conversation-details">
+                  <div className="conversation-id" title={conv.firstMessage}>
+                    {conv.firstMessage?.length > 28
+                      ? conv.firstMessage.slice(0, 28) + "…"
+                      : conv.firstMessage}
+                  </div>
+                  <div className="conversation-status">
+                    <span className="conv-ended-badge">Ended</span>
+                  </div>
+                  <div className="conversation-unread" />
+                </div>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      {/* Right panel */}
+      <div className="chat-panel">
+        <div className="chat-header">
+          <h2>
+            {(() => {
+              if (selectedPastConv) return selectedPastConv.firstMessage || `Conversation ${selectedPastConv.id}`;
+              const first = messages.find((m) => m.sender === "You")?.content;
+              return first || "New conversation";
+            })()}
+          </h2>
+          <div className="chat-status">
+            <span className={`status-${connectionStatus}`}>
+              {displayedEnded ? "" : `Status: ${statusLabel[connectionStatus]}`}
+            </span>
+            {wsOpen && !ended && !selectedPastConv && (
+              <button
+                className="end-conv-button"
+                onClick={endConversation}
+                title="End this conversation"
+              >
+                End Conversation
+              </button>
+            )}
+            {displayedEnded && <span className="conv-ended-badge">Ended</span>}
+          </div>
+        </div>
+
+        <div className="chat-messages">
+          {/* Spacer: grows to push a short message list to the bottom; collapses when list is long so scroll works */}
+          <div style={{ flex: 1 }} />
+          {displayedLoading ? (
+            <div className="empty-state"><p>Loading…</p></div>
+          ) : displayedMessages.length === 0 && !displayedEnded ? (
+            <div className="empty-state">
+              <p>Start your conversation by typing a message below</p>
+            </div>
+          ) : (
+            displayedMessages.map((msg) => (
+              <div
+                key={msg.id}
+                className={`message ${msg.sender === "You" ? "message-user" : "message-admin"}`}
+              >
+                <div className="message-content">
+                  <div className="message-header">
+                    <span className="message-sender">
+                      [{msg.sender}, {formatTime(msg.timestamp)}]:
+                    </span>
+                  </div>
+                  <div className="message-text">
+                    {renderContent(msg.content)}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+          {/* Ended divider — shown below the last message for ended convs */}
+          {displayedEnded && (
+            <div className="conv-ended-divider">
+              <span>Conversation ended</span>
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <div className="chat-input-container">
+          {ended ? (
+            /* Conversation ended — show "Start new conversation" regardless of which past conv is selected */
+            <div className="new-conv-prompt">
+              <button
+                className="new-conv-button"
+                onClick={startNewConversation}
+                disabled={!wsOpen}
+              >
+                <Add size={18} />
+                Start new conversation
+              </button>
+            </div>
+          ) : selectedPastConv ? null : (
+            /* Active conv and no past conv selected — show the input bar */
+            <div className="chat-input-wrapper">
+              <input
+                type="text"
+                className="chat-input"
+                placeholder="Type your message…"
+                value={inputMessage}
+                onChange={(e) => setInputMessage(e.target.value)}
+                onKeyDown={onKeyDown}
+                disabled={!wsOpen}
+              />
+              <button
+                className="send-button"
+                onClick={sendMessage}
+                disabled={!inputMessage.trim() || !wsOpen}
+              >
+                <Send size={20} />
+                <span>Send</span>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatSupport;

--- a/web/src/components/Header.jsx
+++ b/web/src/components/Header.jsx
@@ -130,6 +130,9 @@ const HeaderNav = ({ onSideNavToggle }) => {
                 <HeaderMenuItem onClick={() => setActionProps(action)}>
                   Feedback
                 </HeaderMenuItem>
+                <HeaderMenuItem as={Link} to="/chat-support">
+                  Chat
+                </HeaderMenuItem>
                 <ToastNotify
                   title={title}
                   subtitle={message}
@@ -179,6 +182,7 @@ const HeaderNav = ({ onSideNavToggle }) => {
                   {isAdmin && <MenuLink url="/users" label="Users" />}
                   {isAdmin && <MenuLink url="/events" label="Events" />}
                   {isAdmin && <MenuLink url="/maintenance" label="Maintenance" />}
+                  {isAdmin && <MenuLink url="/chat-admin" label="Chat" />}
                 </SideNavItems>
               </SideNav>
               </div>

--- a/web/src/styles/chat-support.scss
+++ b/web/src/styles/chat-support.scss
@@ -1,0 +1,508 @@
+.chat-support-container {
+  display: flex;
+  height: calc(100vh - 48px);
+  background-color: #f4f4f4;
+
+  // ── Left panel ──────────────────────────────────────────────────────────────
+  .conversations-panel {
+    width: 300px;
+    min-width: 220px;
+    background-color: #ffffff;
+    border-right: 1px solid #e0e0e0;
+    display: flex;
+    flex-direction: column;
+
+    .conversations-header {
+      padding: 16px 20px;
+      border-bottom: 1px solid #e0e0e0;
+
+      h3 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 600;
+        color: #161616;
+      }
+
+      // When header contains both h3 and a refresh button (admin panel)
+      &:has(button) {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        h3 {
+          flex: 1;
+        }
+      }
+    }
+
+    .conversations-list {
+      flex: 1;
+      overflow-y: auto;
+
+      .conversation-item {
+        display: flex;
+        padding: 14px 18px;
+        cursor: pointer;
+        border-bottom: 1px solid #e0e0e0;
+
+        &:hover {
+          background-color: #f4f4f4;
+        }
+
+        &.active {
+          background-color: #e8e8e8;
+          border-left: 3px solid #0f62fe;
+        }
+
+        &.conversation-item--ended {
+          opacity: 0.6;
+          cursor: default;
+          border-left: 3px solid #c6c6c6;
+
+          &:hover {
+            background-color: transparent;
+          }
+        }
+
+        .conversation-avatar {
+          margin-right: 12px;
+          flex-shrink: 0;
+
+          .avatar-circle {
+            width: 38px;
+            height: 38px;
+            border-radius: 50%;
+            background-color: #0f62fe;
+            color: #ffffff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 15px;
+
+            &.avatar-circle--ended {
+              background-color: #8d8d8d;
+            }
+          }
+        }
+
+        .conversation-details {
+          flex: 1;
+          overflow: hidden;
+
+          .conversation-id {
+            font-weight: 600;
+            font-size: 15px;
+            color: #161616;
+            margin-bottom: 3px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .conversation-status {
+            font-size: 13px;
+            margin-bottom: 3px;
+
+            &.status-connected,
+            &.status-active {
+              color: #24a148;
+            }
+
+            &.status-disconnected,
+            &.status-reconnecting {
+              color: #f1620a;
+            }
+
+            &.status-error {
+              color: #da1e28;
+            }
+
+            &.status-connecting {
+              color: #8d8d8d;
+            }
+          }
+
+          .conversation-unread {
+            font-size: 12px;
+            color: #525252;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+
+            .unread-dot {
+              display: inline-block;
+              width: 8px;
+              height: 8px;
+              border-radius: 50%;
+              background-color: #0f62fe;
+              flex-shrink: 0;
+            }
+          }
+        }
+      }
+    }
+
+    .empty-state-text {
+      padding: 20px;
+      font-size: 13px;
+      color: #8d8d8d;
+      text-align: center;
+    }
+  }
+
+  // ── Right panel ─────────────────────────────────────────────────────────────
+  .chat-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+    min-width: 0;
+
+    .chat-header {
+      padding: 18px 24px;
+      border-bottom: 1px solid #e0e0e0;
+      background-color: #f4f4f4;
+      flex-shrink: 0;
+
+      h2 {
+        margin: 0 0 6px;
+        font-size: 18px;
+        font-weight: 600;
+        color: #161616;
+      }
+
+      .chat-status {
+        font-size: 13px;
+        color: #525252;
+
+        .status-label {
+          color: #161616;
+        }
+
+        .status-divider {
+          margin: 0 8px;
+          color: #8d8d8d;
+        }
+
+        .status-connected,
+        .status-active {
+          color: #24a148;
+          font-weight: 500;
+        }
+
+        .status-disconnected {
+          color: #f1620a;
+        }
+
+        .status-error {
+          color: #da1e28;
+        }
+      }
+    }
+
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px;
+      background-color: #fafafa;
+      display: flex;
+      flex-direction: column;
+
+      .empty-state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+
+        p {
+          color: #8d8d8d;
+          font-size: 15px;
+        }
+      }
+
+      .message {
+        margin-bottom: 18px;
+        display: flex;
+
+        // Default (user view): own messages right, admin messages left.
+        &.message-user {
+          justify-content: flex-end;
+
+          .message-content {
+            background-color: #e0e0e0;
+            border-radius: 8px 8px 0 8px;
+            max-width: 65%;
+          }
+        }
+
+        &.message-admin {
+          justify-content: flex-start;
+
+          .message-content {
+            background-color: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px 8px 8px 0;
+            max-width: 65%;
+          }
+        }
+
+        .message-content {
+          padding: 10px 14px;
+
+          .message-header {
+            margin-bottom: 4px;
+
+            .message-sender {
+              font-size: 12px;
+              color: #525252;
+              font-weight: 500;
+            }
+          }
+
+          .message-text {
+            font-size: 14px;
+            color: #161616;
+            line-height: 1.5;
+            word-wrap: break-word;
+
+            a {
+              color: #0f62fe;
+              text-decoration: underline;
+
+              &:hover {
+                color: #0353e9;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // ── Ended divider — shown below the last message when conv is closed ────────
+    .conv-ended-divider {
+      display: flex;
+      align-items: center;
+      margin: 20px 0 8px;
+
+      &::before,
+      &::after {
+        content: "";
+        flex: 1;
+        height: 1px;
+        background: #c6c6c6;
+      }
+
+      span {
+        padding: 0 12px;
+        font-size: 12px;
+        color: #8d8d8d;
+        white-space: nowrap;
+      }
+    }
+
+    // ── Input area ─────────────────────────────────────────────────────────────
+    .chat-input-container {
+      padding: 16px 24px;
+      border-top: 1px solid #e0e0e0;
+      background-color: #ffffff;
+      flex-shrink: 0;
+
+      .chat-input-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+
+        .chat-input {
+          flex: 1;
+          padding: 10px 14px;
+          border: 1px solid #8d8d8d;
+          border-radius: 4px;
+          font-size: 14px;
+          outline: none;
+
+          &:focus {
+            border-color: #0f62fe;
+          }
+
+          &::placeholder {
+            color: #8d8d8d;
+          }
+
+          &:disabled {
+            background-color: #f4f4f4;
+            cursor: not-allowed;
+          }
+        }
+
+        // Admin reply uses a textarea instead of input
+        &.admin-reply-wrapper {
+          align-items: flex-end;
+
+          .chat-textarea {
+            flex: 1;
+
+            textarea {
+              resize: none;
+              font-size: 14px;
+            }
+          }
+        }
+
+        .send-button {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 10px 20px;
+          background-color: #0f62fe;
+          color: #ffffff;
+          border: none;
+          border-radius: 4px;
+          font-size: 14px;
+          font-weight: 500;
+          cursor: pointer;
+          white-space: nowrap;
+          flex-shrink: 0;
+
+          &:hover:not(:disabled) {
+            background-color: #0353e9;
+          }
+
+          &:disabled {
+            background-color: #c6c6c6;
+            cursor: not-allowed;
+          }
+        }
+      }
+
+      // ── "Start new conversation" prompt shown when conv is ended ─────────────
+      .new-conv-prompt {
+        display: flex;
+        justify-content: center;
+        padding: 8px 0;
+
+        .new-conv-button {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 10px 24px;
+          background-color: #0f62fe;
+          color: #ffffff;
+          border: none;
+          border-radius: 4px;
+          font-size: 14px;
+          font-weight: 500;
+          cursor: pointer;
+
+          &:hover:not(:disabled) {
+            background-color: #0353e9;
+          }
+
+          &:disabled {
+            background-color: #c6c6c6;
+            cursor: not-allowed;
+          }
+        }
+      }
+    }
+
+    // ── Empty state when no conversation is selected (admin) ───────────────────
+    > .empty-state {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      p {
+        color: #8d8d8d;
+        font-size: 15px;
+      }
+    }
+  }
+
+  // ── End-conversation button (user + admin header)
+  .end-conv-button {
+    margin-left: 16px;
+    padding: 4px 12px;
+    background: transparent;
+    border: 1px solid #da1e28;
+    border-radius: 4px;
+    color: #da1e28;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover {
+      background-color: #da1e28;
+      color: #ffffff;
+    }
+  }
+
+  .conv-ended-badge {
+    margin-left: 16px;
+    padding: 3px 10px;
+    background-color: #f4f4f4;
+    border: 1px solid #c6c6c6;
+    border-radius: 4px;
+    color: #525252;
+    font-size: 12px;
+    font-weight: 500;
+  }
+
+  // ── Admin view: flip bubble sides so user msgs are left, admin msgs are right
+  &.chat-support-container--admin {
+    .chat-messages {
+      .message {
+        &.message-user {
+          justify-content: flex-start;
+
+          .message-content {
+            background-color: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px 8px 8px 0;
+          }
+        }
+
+        &.message-admin {
+          justify-content: flex-end;
+
+          .message-content {
+            background-color: #0f62fe;
+            border: none;
+            border-radius: 8px 8px 0 8px;
+
+            .message-sender,
+            .message-text {
+              color: #ffffff;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// ── Scrollbar ──────────────────────────────────────────────────────────────────
+.conversations-list,
+.chat-messages {
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f4f4f4;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #c6c6c6;
+    border-radius: 4px;
+
+    &:hover {
+      background: #8d8d8d;
+    }
+  }
+}

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
         "/pac-go-server": {
           target: proxyTarget,
           changeOrigin: true,
+          ws: true,
           rewrite: (path) => path.replace(/^\/pac-go-server/, '/api/v1'),
         }
       },


### PR DESCRIPTION
This PR integrates a real-time chat support system that allows users to contact admins directly from the power-access-cloud UI.

- User chat widget — users can open a chat panel, send messages, view history, and end conversations. The connection is maintained over WebSocket so messages are delivered instantly without polling.
- Admin chat panel — admins can see all active conversations with live unread indicators, open any conversation to read the full history, reply in real time, and end conversations on behalf of users.
- WebSocket infrastructure — an in-memory pub/sub hub routes messages between the user's session goroutine and the admin's session goroutine without any database polling. Admin replies reach the user's browser in microseconds.
- Persistent history — all messages are stored in MongoDB. When a user reconnects or navigates back to the chat, their full conversation history is restored. Ended conversations are recorded with a sentinel so the state survives server restarts.
- Async DB writes — admin replies are written to the database via a background worker queue so the admin UI never blocks waiting for a DB round trip.